### PR TITLE
Line numbers incorrect in the compiler messages

### DIFF
--- a/app/src/processing/app/preproc/PdePreprocessor.java
+++ b/app/src/processing/app/preproc/PdePreprocessor.java
@@ -196,9 +196,7 @@ public class PdePreprocessor {
 
   // Write the pde program to the cpp file
   protected void writeProgram(PrintStream out, String program, List<String> prototypes) {
-    int prototypeInsertionPoint = firstStatement(program);
-  
-    out.print(program.substring(0, prototypeInsertionPoint));
+ 
     String arch = Base.getArch();
     if(arch == "msp430") out.print("#include \"Energia.h\"\n");    
     else out.print("#include \"Arduino.h\"\n");    
@@ -207,8 +205,8 @@ public class PdePreprocessor {
     for (int i = 0; i < prototypes.size(); i++) {
       out.print(prototypes.get(i) + "\n");
     }
-    
-    out.print(program.substring(prototypeInsertionPoint));
+    out.print("#line 1\n");
+    out.print(program.substring(0));
   }
 
 


### PR DESCRIPTION
The reported line-numbers do not correspond to the line numbers in the source files.
This is a generic arduino/wiring bug, as there are (include) lines inserted in the source file
prior to compilation. This messes up the line numbering.

There is a way around: include "#line xxx" directives in the source file after the insertion of include lines.
see: http://www.delorie.com/gnu/docs/gcc/cpp_44.html.

This way, you can also implement a parser for the debug window, that jumps directly to the offending line number
and column when you double-click on a line, or highlight the source code. (just parse the debug window for lines
with the form [filename]:[line]:[column]:error:[xxxxxx] and highlight all these lines in the source window.
