### PR TITLE
Add -DENERGIA=101 Pre-Processor Option for gcc and g++

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -42,7 +42,7 @@ import static processing.app.I18n._;
  * files and images, etc) that comes from that.
  */
 public class Base {
-  public static final int REVISION = 101;
+  public static final int REVISION = 6;
   /** This might be replaced by main() if there's a lib/version.txt file. */
   static String VERSION_NAME = "0101E0006";
   /** Set true if this a proper release rather than a numbered revision. */

--- a/app/src/processing/app/debug/Compiler.java
+++ b/app/src/processing/app/debug/Compiler.java
@@ -578,7 +578,7 @@ public class Compiler implements MessageConsumer {
           "-g", // include debugging info (so errors include line numbers)
           "-mmcu=" + boardPreferences.get("build.mcu"),
           "-DF_CPU=" + boardPreferences.get("build.f_cpu"),
-          "-DARDUINO=" + Base.REVISION,
+          "-DENERGIA=" + Base.REVISION,
         }));
     } else {
         baseCommandCompiler = new ArrayList(Arrays.asList(new String[] {
@@ -619,7 +619,7 @@ public class Compiler implements MessageConsumer {
         "-fdata-sections",
         "-mmcu=" + boardPreferences.get("build.mcu"),
         "-DF_CPU=" + boardPreferences.get("build.f_cpu"),
-        "-DARDUINO=" + Base.REVISION,
+        "-DENERGIA=" + Base.REVISION,
       }));
       } else { // default to avr
         baseCommandCompiler = new ArrayList(Arrays.asList(new String[] {
@@ -666,7 +666,7 @@ public class Compiler implements MessageConsumer {
         "-fdata-sections",
         "-mmcu=" + boardPreferences.get("build.mcu"),
         "-DF_CPU=" + boardPreferences.get("build.f_cpu"),
-        "-DARDUINO=" + Base.REVISION,
+        "-DENERGIA=" + Base.REVISION,
       }));
     } else { // default to avr
       baseCommandCompilerCPP = new ArrayList(Arrays.asList(new String[] {


### PR DESCRIPTION
Either
- Replace `-DARDUINO=101` by `-DENERGIA=101` 

or
- Add `-DENERGIA=101` along `-DARDUINO=101` 

for gcc and g++ as in

```
/Applications/Energia.app/Contents/Resources/Java/hardware/tools/msp430/bin/msp430-g++ 
-c -g -Os -Wall 
-ffunction-sections -fdata-sections 
-mmcu=msp430g2553 -DF_CPU=16000000L -DARDUINO=101 
-I/Applications/Energia.app/Contents/Resources/Java/hardware/msp430/cores/msp430 
-I/Applications/Energia.app/Contents/Resources/Java/hardware/msp430/variants/launchpad 
/var/tmp/DualBlink_430.cpp -o /var/tmp/DualBlink_430.cpp.o 
```
