### PR TITLE
digitalWrite leaves pin in PWM mode if PWM was previously enabled with analogWrite

### DIFF
--- a/hardware/msp430/cores/msp430/wiring_digital.c
+++ b/hardware/msp430/cores/msp430/wiring_digital.c
@@ -79,8 +79,16 @@ void digitalWrite(uint8_t pin, uint8_t val)
 	uint8_t bit = digitalPinToBitMask(pin);
 	uint8_t port = digitalPinToPort(pin);
 	volatile uint16_t *out;
+	volatile uint16_t *sel;
 
 	if (port == NOT_A_PORT) return;
+
+	/*
+	 * Clear bit in PxSEL register to select GPIO function. Other functions like analogWrite(...) 
+	 * will set this bit so need to clear it.
+	 */
+	sel = portSelRegister(port);	/* get the port function select register address */
+	*sel &= ~bit;			/* clear bit in pin function select register */
 
 	out = portOutputRegister(port);
 


### PR DESCRIPTION
Following sketch does not work. LED pin stays at 14 due to digitalWrite not disabling PWM if previously enabled.

```
void setup() {
  pinMode(GREEN_LED, OUTPUT);
}

void loop(){
digitalWrite(GREEN_LED, HIGH);
delay(2000);  
analogWrite(GREEN_LED,14);
delay(2000);
}
```
