### PR TITLE
EEPROM/Flash ISP functions not supported

### DIFF
--- a/hardware/msp430/cores/msp430/Energia.h
+++ b/hardware/msp430/cores/msp430/Energia.h
@@ -144,6 +144,8 @@ extern const uint16_t port_to_output[];
 void delayMicroseconds(unsigned int us);
 unsigned long micros();
 unsigned long millis();
+void disableWatchDog();
+void enableWatchDog();
 
 #ifdef __cplusplus
 } // extern "C"

--- a/hardware/msp430/cores/msp430/wiring.c
+++ b/hardware/msp430/cores/msp430/wiring.c
@@ -32,7 +32,6 @@
 
 void initClocks(void);
 void enableWatchDogIntervalMode(void);
-void disableWatchDog(void);
 
 void init()
 {
@@ -42,10 +41,15 @@ void init()
         __eint();
 }
 
-void disableWatchDog(void)
+void disableWatchDog()
 {
         /* Diable watchdog timer */
 	WDTCTL = WDTPW | WDTHOLD;
+}
+
+void enableWatchDog()
+{
+	enableWatchDogIntervalMode();
 }
 
 void enableWatchDogIntervalMode(void)

--- a/hardware/msp430/libraries/MspFlash/MspFlash.cpp
+++ b/hardware/msp430/libraries/MspFlash/MspFlash.cpp
@@ -18,6 +18,7 @@
 */
 #include "MspFlash.h"
 #include <msp430.h>
+#include <Energia.h>
 
 // The Flash clock must be between 200 and 400 kHz to operate correctly
 // TODO: calculate correct devider (0..64) depending on clock frequenct (F_CPU)
@@ -28,13 +29,13 @@
 // erase flash, make sure pointer is in the segment you wish to erase, otherwise you may erase you program or some data
 void MspFlashClass::erase(unsigned char *flash)
 {
-  WDTCTL = WDTPW+WDTHOLD;   // Disable WDT
+  disableWatchDog();        // Disable WDT
   FCTL2 = FWKEY+FLASHCLOCK; // SMCLK/2
   FCTL3 = FWKEY;            // Clear LOCK
   FCTL1 = FWKEY+ERASE;      //Enable segment erase
   *flash = 0;               // Dummy write, erase Segment
   FCTL3 = FWKEY+LOCK;       // Done, set LOCK
-  WDTCTL = WDTPW;           // Enable WDT
+  enableWatchDog();         // Enable WDT
 }
 
 // load from memory, at segment boundary
@@ -47,7 +48,7 @@ void MspFlashClass::read(unsigned char *flash, unsigned char *dest, int len)
 // save in to flash (at segment boundary)
 void MspFlashClass::write(unsigned char *flash, unsigned char *src, int len)
 {
- WDTCTL = WDTPW+WDTHOLD;   // Disable WDT
+ disableWatchDog();        // Disable WDT
  FCTL2 = FWKEY+FLASHCLOCK; // SMCLK/2 
  FCTL3 = FWKEY;            // Clear LOCK
  FCTL1 = FWKEY+WRT;        // Enable write
@@ -55,7 +56,7 @@ void MspFlashClass::write(unsigned char *flash, unsigned char *src, int len)
    *(flash++) = *(src++);
  FCTL1 = FWKEY;            //Done. Clear WRT
  FCTL3 = FWKEY+LOCK;       // Set LOCK
-  WDTCTL = WDTPW;           // Enable WDT  
+ enableWatchDog();         // Enable WDT
 }
 
 MspFlashClass Flash;


### PR DESCRIPTION
As the MSP430 does not have EEPROM onboard, the Arduino EEPROM library cannot be implemented.
However: You can use FLASH for persistent storage (with the usual flash limitations that you cannot write individual bytes).

A library to to access the FLASH memory controller could provide on-chip persistent storage in the INFO_B to INFO_D segments.
