### PR TITLE
Fix I2C stop condition when receiving 1 byte with USCI

### DIFF
--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -266,6 +266,11 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
 #ifdef __MSP430_HAS_USCI__
     twi_state =  TWI_MRX;                     // Master receive mode
     UCB0CTL1 |= UCTXSTT;                      // I2C start condition
+
+    if(length == 1) {                         // When only receiving 1 byte..
+        while(UCB0CTL1 & UCTXSTT);            // Wait for start bit to be sent
+        UCB0CTL1 |= UCTXSTP;                  // Send I2C stop condition after recv
+    }
 #endif
 #ifdef __MSP430_HAS_EUSCI_B0__
     twi_state =  TWI_MRX;                     // Master receive mode


### PR DESCRIPTION
According to MSP430x2xxx family guide, page 473:

If a master wants to receive a single byte only, the UCTXSTP bit must be
set while the byte is being received. For this case, the UCTXSTT may be
polled to determine when it is cleared:

```
    BIS.B #UCTXSTT,&UCBOCTL1 ;Transmit START cond.
POLL_STT BIT.B #UCTXSTT,&UCBOCTL1 ;Poll UCTXSTT bit
    JC POLL_STT              ;When cleared,
    BIS.B #UCTXSTP,&UCB0CTL1 ;transmit STOP cond.
```

Thread on 43oh: http://forum.43oh.com/topic/3154-i2c-issues/
