### PR TITLE
Corrected links to pinout images in Stellaris Launchpad reference

### DIFF
--- a/reference/Guide_StellarisLaunchPad.html
+++ b/reference/Guide_StellarisLaunchPad.html
@@ -51,8 +51,8 @@ type='text/css' />
 <p>The following diagram shows the complete pin map for the StellarPad LM4F in Energia. 
 </p>
 
-<p><img src="../reference/img/StellarPadLM4F120H5QR-v1.0.jpg" height="500" width="850"></p>
-<p><img src="../reference/img/StellarPadLM4F120H5QR-v1.0BACK.jpg" height="500" width="850"></p>
+<p><img src="../reference/img/StellarPadLM4F120H5QR-V1.0.jpg" height="500" width="850"></p>
+<p><img src="../reference/img/StellarPadLM4F120H5QR-V1.0BACK.jpg" height="500" width="850"></p>
 
 </div>
 


### PR DESCRIPTION
In Stellaris Launchpad reference page links to images had errors resulting in not displaying them. Target file names were corrected.
