### PR TITLE
GPIO and timer initializes moved to _init(), run before C++ constructors...

### DIFF
--- a/hardware/lm4f/cores/lm4f/main.cpp
+++ b/hardware/lm4f/cores/lm4f/main.cpp
@@ -15,49 +15,56 @@
 #include "driverlib/sysctl.h"
 #include "driverlib/eeprom.h"
 
-int main(void)
+#ifdef __cplusplus
+extern "C" {
+
+void _init(void)
 {
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_EEPROM0);
+	if(ROM_EEPROMInit() == EEPROM_INIT_ERROR) {
+		if(ROM_EEPROMInit() != EEPROM_INIT_ERROR)
+			EEPROMMassErase();
+	}
 
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_EEPROM0);
-    if(ROM_EEPROMInit() == EEPROM_INIT_ERROR) {
-    	if(ROM_EEPROMInit() != EEPROM_INIT_ERROR)
-    		EEPROMMassErase();
-    }
-
-    timerInit();
+	timerInit();
 
 	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOA);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOB);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOC);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOB);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOC);
 	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOD);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOE);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOF);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOG);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOH);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOJ);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOK);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOL);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOM);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPION);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOP);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOQ);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOE);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOF);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOG);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOH);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOJ);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOK);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOL);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOM);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPION);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOP);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOQ);
 #ifdef TARGET_IS_SNOWFLAKE_RA0
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOR);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOS);
-    ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOT);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOR);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOS);
+	ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOT);
 #endif
 
-    //Unlock and commit NMI pins PD7 and PF0
-    HWREG(GPIO_PORTF_BASE + GPIO_O_LOCK) = 0x4C4F434B;
-    HWREG(GPIO_PORTF_BASE + GPIO_O_CR) |= 0x1;
-    HWREG(GPIO_PORTD_BASE + GPIO_O_LOCK) = 0x4C4F434B;
-    HWREG(GPIO_PORTD_BASE + GPIO_O_CR) |= 0x80;
+	//Unlock and commit NMI pins PD7 and PF0
+	HWREG(GPIO_PORTF_BASE + GPIO_O_LOCK) = 0x4C4F434B;
+	HWREG(GPIO_PORTF_BASE + GPIO_O_CR) |= 0x1;
+	HWREG(GPIO_PORTD_BASE + GPIO_O_LOCK) = 0x4C4F434B;
+	HWREG(GPIO_PORTD_BASE + GPIO_O_CR) |= 0x80;
+} /* void _init(void) */
 
-    setup();
+} /* extern "C" */
+#endif
 
-    for (;;) {
-        loop();
-        if (serialEventRun) serialEventRun();
-    }
+int main(void)
+{
+	setup();
 
+	for (;;) {
+		loop();
+		if (serialEventRun) serialEventRun();
+	}
 }

--- a/hardware/lm4f/cores/lm4f/startup_gcc.c
+++ b/hardware/lm4f/cores/lm4f/startup_gcc.c
@@ -417,6 +417,7 @@ extern void (*__preinit_array_start[])(void);
 extern void (*__preinit_array_end[])(void);
 extern void (*__init_array_start[])(void);
 extern void (*__init_array_end[])(void);
+extern void _init(void);
 
 
 //*****************************************************************************
@@ -470,6 +471,8 @@ void ResetISR(void) {
     cnt = __preinit_array_end - __preinit_array_start;
     for (i = 0; i < cnt; i++)
         __preinit_array_start[i]();
+
+    _init();
 
     cnt = __init_array_end - __init_array_start;
     for (i = 0; i < cnt; i++)


### PR DESCRIPTION
... to facilitate pragmatic compatibility with more Arduino libraries.
