### PR TITLE
Debounce example does not work properly.

### DIFF
--- a/build/shared/examples/2.Digital/Debounce/Debounce.ino
+++ b/build/shared/examples/2.Digital/Debounce/Debounce.ino
@@ -43,7 +43,7 @@ long lastDebounceTime = 0;  // the last time the output pin was toggled
 long debounceDelay = 50;    // the debounce time; increase if the output flickers
 
 void setup() {
-  pinMode(buttonPin, INPUT);
+  pinMode(buttonPin, INPUT_PULLUP);
   pinMode(ledPin, OUTPUT);
 }
 


### PR DESCRIPTION
Using Energia 0101E0012, with LP 1.5 and G2542.
The example Debounce sketch does not work properly.

Pressing "PUSH2" (or P1.3 or S2 as labeled on the silkscreen) does not toggle GREEN_LED.

Changing the pinMode statement in setup() from 
"  pinMode(buttonPin, INPUT);"
to
"  pinMode(buttonPin, INPUT_PULLUP);"
fixes the problem as would be expected since the switch connects to ground. So when the 'pin' is high (due to pull-up) GREEN_LED is lit and pressing PUSH2 grounds it and causes GREEN_LED to turn off.
