### PR TITLE
Launchpad with '2231 has TEMPSENSOR on A10

### DIFF
--- a/hardware/msp430/variants/fraunchpad/pins_energia.h
+++ b/hardware/msp430/variants/fraunchpad/pins_energia.h
@@ -150,7 +150,7 @@ static const uint8_t GREEN_LED = 28;
 
 static const uint8_t PUSH1 = 23;
 static const uint8_t PUSH2 = 29;
-static const uint8_t TEMPSENSOR = 10;
+static const uint8_t TEMPSENSOR = A10;
 
 #ifdef ARDUINO_MAIN
 

--- a/hardware/msp430/variants/launchpad/pins_energia.h
+++ b/hardware/msp430/variants/launchpad/pins_energia.h
@@ -119,7 +119,7 @@ static const uint8_t P2_6 = 19;
 static const uint8_t RED_LED = 2;
 static const uint8_t GREEN_LED = 14;
 static const uint8_t PUSH2 = 5;
-static const uint8_t TEMPSENSOR = 10; // depends on chip
+static const uint8_t TEMPSENSOR = A10; // depends on chip
 
 
 #ifdef ARDUINO_MAIN

--- a/hardware/msp430/variants/launchpad_f5529/pins_energia.h
+++ b/hardware/msp430/variants/launchpad_f5529/pins_energia.h
@@ -165,7 +165,7 @@ static const uint8_t PUSH1 = 41;
 static const uint8_t PUSH2 = 42;
 static const uint8_t RED_LED = 43;
 static const uint8_t GREEN_LED = 44;
-static const uint8_t TEMPSENSOR = 10;
+static const uint8_t TEMPSENSOR = A10;
 
 #ifdef ARDUINO_MAIN
 

--- a/hardware/msp430/variants/launchpad_fr5969/pins_energia.h
+++ b/hardware/msp430/variants/launchpad_fr5969/pins_energia.h
@@ -78,7 +78,7 @@ static const uint8_t A6  = 128 + 6; // Not available on BoosterPack header
 static const uint8_t A7  = 128 + 7; // Not available on BoosterPack header
 static const uint8_t A8  = 23; // Available, but not on the 20-pin BP header
 static const uint8_t A9  = 24; // Available, but not on the 20-pin BP header
-static const uint8_t A10 = 2; 	
+static const uint8_t A10 = 128 + 10;
 static const uint8_t A11  = 5;
 static const uint8_t A12  = 18; 
 static const uint8_t A13  = 128 + 13;  // Not available on BoosterPack header
@@ -184,7 +184,7 @@ static const uint8_t GREEN_LED = 26;
 
 static const uint8_t PUSH1 = 27;
 static const uint8_t PUSH2 = 28;
-static const uint8_t TEMPSENSOR = 30; // depends on chip
+static const uint8_t TEMPSENSOR = A10; // depends on chip
 
 #ifdef ARDUINO_MAIN
 


### PR DESCRIPTION
pins_energia.h has:

```
static const uint8_t TEMPSENSOR = 10;
```

For the '2231 it seems this needs to be

```
static const uint8_t TEMPSENSOR = A10;
```
