### PR TITLE
Disable interrupts while manipulating port mapping control on MSP430

### DIFF
--- a/hardware/msp430/cores/msp430/wiring_digital.c
+++ b/hardware/msp430/cores/msp430/wiring_digital.c
@@ -162,10 +162,18 @@ void pinMode_int(uint8_t pin, uint16_t mode)
 
 	if(pmreg == NOT_A_PIN) return;
 
-	PMAPPWD = PMAPKEY;
+	// Store current interrupt state, then disable all interrupts, to avoid that the port map is put into read only mode
+	uint16_t globalInterruptState = __read_status_register() & GIE;
+	__disable_interrupt();
+
+	PMAPKEYID = PMAPKEY;
 	PMAPCTL |= PMAPRECFG;
 	*(pmreg + bit_pos(bit)) = (mode >> 8) & 0xff;
-	PMAPPWD = 0x0;
+	// Make port map control read only by writing invalid password
+	PMAPKEYID = 0x0;
+
+	// Restore previous interrupt state
+	__bis_SR_register(globalInterruptState);
 #endif
 }
 


### PR DESCRIPTION
Disable interrupts while manipulating port mapping control, since the port
mapping will forever be read only if the configuration takes more than 32
(assembler) instructions, this is specified in
http://www.ti.com/lit/ug/slau208n/slau208n.pdf, section "13.2 Port Mapping Controller Operation", page 426

Use PMAPKEYID instead of PMAPPWD, which is deprecated, when setting port mapping password.
