### PR TITLE
CC3200 - WiFiClient available() blocks

### DIFF
--- a/hardware/cc3200/libraries/WiFi/WiFiUdp.cpp
+++ b/hardware/cc3200/libraries/WiFi/WiFiUdp.cpp
@@ -326,17 +326,23 @@ int WiFiUDP::read()
 }
 
 //--tested, working--//
-int WiFiUDP::read(unsigned char* buffer, size_t len)
+int WiFiUDP::read(unsigned char* buffer, size_t size)
 {
     //
     //read the requested number of bytes into the buffer
-    //this won't read past the end of the data since read() handles that
+    //uses direct buffer copy for efficiency
     //
-    int i;
-    for (i = 0; i < len; i++) {
-        buffer[i] = read();
+    if (rx_currentIndex >= rx_fillLevel) {
+        return 0;
     }
-    return i;
+    int len = rx_fillLevel - rx_currentIndex;
+    if (len > size) {
+        len = size;
+    }
+    memcpy(buffer, &rx_buf[rx_currentIndex], len);
+    rx_currentIndex += len;
+
+    return len;
 }
 
 //--tested, working--//
@@ -345,6 +351,9 @@ int WiFiUDP::peek()
     //
     //return the next byte without incrementing the index counter
     //
+    if (rx_currentIndex >= rx_fillLevel) {
+        return -1;
+    }
     return rx_buf[rx_currentIndex];
 }
 

--- a/hardware/cc3200/libraries/WiFi/WiFiUdp.h
+++ b/hardware/cc3200/libraries/WiFi/WiFiUdp.h
@@ -79,10 +79,10 @@ public:
     int read();
     // Read up to len bytes from the current packet and place them into buffer
     // Returns the number of bytes read, or 0 if none are available
-    int read(unsigned char* buffer, size_t len);
+    int read(unsigned char* buffer, size_t size);
     // Read up to len characters from the current packet and place them into buffer
     // Returns the number of characters read, or 0 if none are available
-    int read(char* buffer, size_t len) { return read((unsigned char*)buffer, len); };
+    int read(char* buffer, size_t size) { return read((unsigned char*)buffer, size); };
     // Return the next byte from the current packet without moving on to the next byte
     int peek();
     void flush();	// Finish reading the current packet


### PR DESCRIPTION
Is there a way to make the WiFiClient.available() perform its work without blocking waiting for incoming data?  I also noticed the WiFiClient.read(buf, len) function will wait until "len" bytes have actually been read, rather than taking it as advisement on a maximum size.

By contrast the TM4C1294's EthernetClient library works available() in a non-blocking manner and read(buf, len) returns right away with "up to len" bytes.
