### PR TITLE
Emulate SPI.setBitOrder(LSBFIRST) for LM4F and CC3200

### DIFF
--- a/hardware/cc3200/libraries/SPI/SPI.h
+++ b/hardware/cc3200/libraries/SPI/SPI.h
@@ -33,10 +33,14 @@
 #define SPI_EXTCLK_MASK 0xFF0 << 4
 #define BOOST_PACK_SPI 0
 
+#define MSBFIRST 1
+#define LSBFIRST 0
+
 class SPIClass
 {
 	private:
 		uint8_t SSIModule;
+		uint8_t SSIBitOrder;
 
 	public:
 		SPIClass(void);

--- a/hardware/lm4f/libraries/SPI/SPI.cpp
+++ b/hardware/lm4f/libraries/SPI/SPI.cpp
@@ -162,10 +162,12 @@ static const unsigned long g_ulSSIPins[] = {
 
 SPIClass::SPIClass(void) {
 	SSIModule = NOT_ACTIVE;
+	SSIBitOrder = MSBFIRST;
 }
 
 SPIClass::SPIClass(uint8_t module) {
 	SSIModule = module;
+	SSIBitOrder = MSBFIRST;
 }
   
 void SPIClass::begin() {
@@ -227,9 +229,11 @@ void SPIClass::end() {
 }
 
 void SPIClass::setBitOrder(uint8_t ssPin, uint8_t bitOrder) {
+	SSIBitOrder = bitOrder;
 }
 
 void SPIClass::setBitOrder(uint8_t bitOrder) {
+	SSIBitOrder = bitOrder;
 }
 
 void SPIClass::setDataMode(uint8_t mode) {
@@ -243,15 +247,24 @@ void SPIClass::setClockDivider(uint8_t divider){
 }
 
 uint8_t SPIClass::transfer(uint8_t data) {
-	unsigned long rxData;
+	unsigned long rxtxData;
 
-	ROM_SSIDataPut(SSIBASE, data);
+	rxtxData = data;
+	if(SSIBitOrder == LSBFIRST) {
+		asm("rbit %0, %1" : "=r" (rxtxData) : "r" (rxtxData));	// reverse order of 32 bits 
+		asm("rev %0, %1" : "=r" (rxtxData) : "r" (rxtxData));	// reverse order of bytes to get original bits into lowest byte 
+	}
+	ROM_SSIDataPut(SSIBASE, (uint8_t) rxtxData);
 
 	while(ROM_SSIBusy(SSIBASE));
 
-	ROM_SSIDataGet(SSIBASE, &rxData);
+	ROM_SSIDataGet(SSIBASE, &rxtxData);
+	if(SSIBitOrder == LSBFIRST) {
+		asm("rbit %0, %1" : "=r" (rxtxData) : "r" (rxtxData));	// reverse order of 32 bits 
+		asm("rev %0, %1" : "=r" (rxtxData) : "r" (rxtxData));	// reverse order of bytes to get original bits into lowest byte 
+	}
 
-	return (uint8_t) rxData;
+	return (uint8_t) rxtxData;
 }
 
 void SPIClass::setModule(uint8_t module) {

--- a/hardware/lm4f/libraries/SPI/SPI.h
+++ b/hardware/lm4f/libraries/SPI/SPI.h
@@ -29,11 +29,15 @@
 
 #define BOOST_PACK_SPI 2
 
+#define MSBFIRST 1
+#define LSBFIRST 0
+
 class SPIClass {
 
 private:
 
 	uint8_t SSIModule;
+	uint8_t SSIBitOrder;
 
 public:
 


### PR DESCRIPTION
As the peripherals only support MSB first, the SPI libraries for Tiva/Stellaris and CC3200 ignore the setBitOrder command. This pull request emulates support for LSB first using ARM instructions to reorder bits before and after transfer.

Also see http://forum.stellarisiti.com/topic/2089-spi-bit-order-on-tiva
