### PR TITLE
CC3200(Energia13b2): UART receive 16 bytes max

### DIFF
--- a/hardware/cc3200/cores/cc3200/HardwareSerial.cpp
+++ b/hardware/cc3200/cores/cc3200/HardwareSerial.cpp
@@ -266,6 +266,11 @@ void HardwareSerial::flush()
 	while(!TX_BUFFER_EMPTY);
 }
 
+HardwareSerial::operator bool()
+{
+	return true;  // Arduino compatibility
+}
+
 size_t HardwareSerial::write(uint8_t c)
 {
 	unsigned int numTransmit = 0;

--- a/hardware/cc3200/cores/cc3200/HardwareSerial.h
+++ b/hardware/cc3200/cores/cc3200/HardwareSerial.h
@@ -68,6 +68,7 @@ class HardwareSerial : public Stream
 		virtual void flush(void);
 		void UARTIntHandler(void);
 		virtual size_t write(uint8_t c);
+		operator bool();
 		using Print::write; // pull in write(str) and write(buf, size) from Print
 };
 


### PR DESCRIPTION
please check this issue, try to send "12345678901234567890" from SerialMonitor...
CC3200 receives only 16 bytes but the same code on Tiva(Energia13b2 too) receives full 20 bytes
Is there a definition of rx buffer for CC3200?

```
#define TIMEOUT 100
#define BUFFSIZ 48
uint8_t  buff[BUFFSIZ+1] = {0};

void setup()
{
  Serial.begin(115200);
  Serial.println("Start");
}

void loop()
{
  uint8_t counter = 0;
  uint8_t bufferLen = 0;
  memset(buff, 0, BUFFSIZ);

  while (bufferLen != BUFFSIZ){
    if (Serial.available()) {    
      buff[bufferLen++] = Serial.read();
      counter = 0;
    } else {
      delay(1);
      counter++;
    }

    if (TIMEOUT == counter) {
     Serial.println("TimeOut");
     break; 
    }
  }

  if (bufferLen > 0) {
    Serial.println(bufferLen);
    Serial.write(buff,bufferLen);
  }
}
```
