### PR TITLE
EthernetClient::write truncates with large writes

### DIFF
--- a/hardware/lm4f/libraries/Ethernet/EthernetUdp.cpp
+++ b/hardware/lm4f/libraries/Ethernet/EthernetUdp.cpp
@@ -219,7 +219,7 @@ int EthernetUDP::read(unsigned char* buffer, size_t len)
 {
 	uint16_t avail = available();
 	uint16_t i;
-	int8_t b;
+	int b;
 
 	if(!avail)
 		return -1;


### PR DESCRIPTION
Per http://forum.43oh.com/topic/5759-ethernet-issue-when-transmit-large-data-on-tm4c1294/

EthernetClient::write's implementation has an unfinished error handler:

```
size_t EthernetClient::write(const uint8_t *buf, size_t size) {
        err_t err = tcp_write(cpcb, buf, size, TCP_WRITE_FLAG_COPY);

        if (err == ERR_MEM) {
                /* TODO: Need to send smaller chunks if fails */
        }

        if(cs->mode) tcp_output(cpcb);
}
```

I have rewritten this function to handle ERR_MEM properly and use it as a flow-control signal so we can stuff lwIP's buffers to the gills for better optimized writes.  Pull request will incorporate issue #389 as well to simplify things.
