### PR TITLE
closed #ifndef from line #18

### DIFF
--- a/hardware/cc3200/libraries/WiFi/examples/ScanNetworks/ScanNetworks.ino
+++ b/hardware/cc3200/libraries/WiFi/examples/ScanNetworks/ScanNetworks.ino
@@ -18,6 +18,7 @@
 #ifndef __CC3200R1M1RGC__
 // Do not include SPI for CC3200 LaunchPad
 #include <SPI.h>
+#endif
 #include <WiFi.h>
 
 void setup() {


### PR DESCRIPTION
line #18:
# ifndef **CC3200R1M1RGC**

was not closed, example now runs on the CC3200-LAUNCHXL
