### PR TITLE
CC3200 WiFiClient::Print(Float) Issue

### DIFF
--- a/hardware/cc3200/libraries/WiFi/WiFiClient.cpp
+++ b/hardware/cc3200/libraries/WiFi/WiFiClient.cpp
@@ -359,11 +359,9 @@ size_t WiFiClient::write(const uint8_t *buffer, size_t size)
     int iRet = sl_Send(WiFiClass::_handleArray[_socketIndex], buffer, size, NULL);
 
     // Flow control signal; perform a paced-retry.
-    if (iRet == SL_EAGAIN) {
-        do {
-            delay(10);
-            iRet = sl_Send(WiFiClass::_handleArray[_socketIndex], buffer, size, NULL);
-        } while (iRet == SL_EAGAIN);
+    while (iRet == SL_EAGAIN) {
+        delay(10);
+        iRet = sl_Send(WiFiClass::_handleArray[_socketIndex], buffer, size, NULL);
     }
 
     if ((iRet < 0) || (iRet != size)) {

--- a/hardware/lm4f/libraries/WiFi/WiFiClient.cpp
+++ b/hardware/lm4f/libraries/WiFi/WiFiClient.cpp
@@ -359,11 +359,9 @@ size_t WiFiClient::write(const uint8_t *buffer, size_t size)
     int iRet = sl_Send(WiFiClass::_handleArray[_socketIndex], buffer, size, NULL);
 
     // Flow control signal; perform a paced-retry.
-    if (iRet == SL_EAGAIN) {
-        do {
-            delay(10);
-            iRet = sl_Send(WiFiClass::_handleArray[_socketIndex], buffer, size, NULL);
-        } while (iRet == SL_EAGAIN);
+    while (iRet == SL_EAGAIN) {
+        delay(10);
+        iRet = sl_Send(WiFiClass::_handleArray[_socketIndex], buffer, size, NULL);
     }
 
     if ((iRet < 0) || (iRet != size)) {

--- a/hardware/msp430/libraries/WiFi/WiFiClient.cpp
+++ b/hardware/msp430/libraries/WiFi/WiFiClient.cpp
@@ -359,11 +359,9 @@ size_t WiFiClient::write(const uint8_t *buffer, size_t size)
     int iRet = sl_Send(WiFiClass::_handleArray[_socketIndex], buffer, size, NULL);
 
     // Flow control signal; perform a paced-retry.
-    if (iRet == SL_EAGAIN) {
-        do {
-            delay(10);
-            iRet = sl_Send(WiFiClass::_handleArray[_socketIndex], buffer, size, NULL);
-        } while (iRet == SL_EAGAIN);
+    while (iRet == SL_EAGAIN) {
+        delay(10);
+        iRet = sl_Send(WiFiClass::_handleArray[_socketIndex], buffer, size, NULL);
     }
 
     if ((iRet < 0) || (iRet != size)) {


### PR DESCRIPTION
Using 0101E0013

I started with SimpleWebServerWifi
In the HTML Section I added.

<code>
client.print("BR Temprature: ");
float TempC = 123.45;
client.print(TempC);
client.println("  BR ");
</code>
<code>
In the browser I get "BR Temprature: 123."
</code>
Nothing ever prints after the decimal place, once you print a float.
If I change the float to an int I get
<code>BR Temprature: 123 BR</code>
Which is correct.

I had to remove the <  > from the br or it wouldn't show here on git hub.
