### PR TITLE
Allow hyphen for library name

### DIFF
--- a/app/src/processing/app/Sketch.java
+++ b/app/src/processing/app/Sketch.java
@@ -2089,7 +2089,7 @@ public class Sketch {
    * systems, i.e. uploading from a Windows machine to a Linux server,
    * or reading a FAT32 partition in OS X and using a thumb drive.
    * <p/>
-   * This helper function replaces everything but A-Z, a-z, and 0-9 with
+   * This helper function replaces everything but A-Z, a-z, 0-9 and hyphen with
    * underscores. Also disallows starting the sketch name with a digit.
    */
   static public String sanitizeName(String origName) {
@@ -2103,7 +2103,8 @@ public class Sketch {
     for (int i = 0; i < c.length; i++) {
       if (((c[i] >= '0') && (c[i] <= '9')) ||
           ((c[i] >= 'a') && (c[i] <= 'z')) ||
-          ((c[i] >= 'A') && (c[i] <= 'Z'))) {
+          ((c[i] >= 'A') && (c[i] <= 'Z')) ||
+          c[i] == '-') {
         buffer.append(c[i]);
 
       } else {


### PR DESCRIPTION
I wrote an article [How to integrate PlatformIO Library Manager to Energia IDE](http://www.ikravets.com/computer-life/platformio/2014/10/07/integration-of-platformio-library-manager-to-arduino-and-energia-ides). But I have a problem with hyphen in library name. See error message:

<img src="http://f.cl.ly/items/1W243A2K2K2k3F2V1910/Screen%20Shot%202014-10-07%20at%2017.04.29.png">

Why hyphen is disallowed? Do you have any problems with it under OS?

P.S: I've started to fill database with [MSP430/Energia libraries](http://platformio.ikravets.com/#!/lib/search?query=msp430) recently. I hope that we will have more Energia's compatible libs in the future.

P.S.S: In this example I used `MSP430-Energia-nRF24` library: [library.json](https://github.com/spirilis/Enrf24/blob/master/library.json) and [Web](http://platformio.ikravets.com/#!/lib/show/MSP430-Energia-nRF24).
