### PR TITLE
CC3200: missing binary.h inside Energia.h

### DIFF
--- a/hardware/cc3200/cores/cc3200/Energia.h
+++ b/hardware/cc3200/cores/cc3200/Energia.h
@@ -9,6 +9,8 @@
 #include <math.h>
 #include <itoa.h>
 
+#include "binary.h"
+
 #include "inc/hw_types.h"  		
 #include "inc/hw_nvic.h" 
 #include "driverlib/gpio.h" 


### PR DESCRIPTION
found by @BigG
http://forum.43oh.com/topic/5974-cc3200-compile-error-when-using-binary-formatter/

please add:
# include "binary.h"

to Energia.h for CC3200 hardware
