### PR TITLE
Wolverine LaunchPad runs out of RAM with CC3100 WiFi library

### DIFF
--- a/hardware/msp430/libraries/WiFi/WiFi.cpp
+++ b/hardware/msp430/libraries/WiFi/WiFi.cpp
@@ -61,6 +61,9 @@ char WiFiClass::fwVersion[] = {0};
 //
 volatile unsigned int WiFiClass::_connectedDeviceCount = 0;
 volatile unsigned int WiFiClass::_latestConnect = 0;
+#ifdef __MSP430_HAS_FRAM__
+__attribute__((section(".text")))
+#endif
 volatile wlanAttachedDevice_t WiFiClass::_connectedDevices[MAX_AP_DEVICE_REGISTRY];
 
 //
@@ -83,6 +86,9 @@ int16_t WiFiClass::_typeArray[MAX_SOCK_NUM];
 uint8_t WiFiClass::pin_nhib = 5;
 uint8_t WiFiClass::pin_cs = 18;
 uint8_t WiFiClass::pin_irq = 19;
+#ifdef __MSP430_HAS_FRAM__
+__attribute__((section(".text")))
+#endif
 WiFiClient WiFiClass::clients[MAX_SOCK_NUM];
 //
 //These "buffers" are used to "return" strings and IpAddress objects


### PR DESCRIPTION
FR5969 LaunchPad doesn't have enough SRAM to fit the generous WiFi buffers:

```
/home/ebrundic/energia-0101E0013/hardware/tools/msp430/bin/../lib/gcc/msp430/4.6.3/../../../../msp430/bin/ld: ScanNetworks.cpp.elf section `.bss' will not fit in region `ram'
/home/ebrundic/energia-0101E0013/hardware/tools/msp430/bin/../lib/gcc/msp430/4.6.3/../../../../msp430/bin/ld: region `ram' overflowed by 1128 bytes
collect2: ld returned 1 exit status
```

So I am going to make a pull request here to push the big WiFi.cpp buffers into FRAM for chips that have it.
