### PR TITLE
INADDR_NONE/MACADDR_NONE need single allocations, more WiFi buffers move to FRAM

### DIFF
--- a/hardware/cc3200/cores/cc3200/IPAddress.cpp
+++ b/hardware/cc3200/cores/cc3200/IPAddress.cpp
@@ -2,6 +2,9 @@
 #include <Arduino.h>
 #include <IPAddress.h>
 
+
+const IPAddress INADDR_NONE(0,0,0,0);
+
 IPAddress::IPAddress()
 {
     memset(_address, 0, sizeof(_address));

--- a/hardware/cc3200/cores/cc3200/IPAddress.h
+++ b/hardware/cc3200/cores/cc3200/IPAddress.h
@@ -70,7 +70,7 @@ public:
     friend class DNSClient;
 };
 
-const IPAddress INADDR_NONE(0,0,0,0);
+extern const IPAddress INADDR_NONE;
 
 
 #endif

--- a/hardware/lm4f/cores/lm4f/IPAddress.cpp
+++ b/hardware/lm4f/cores/lm4f/IPAddress.cpp
@@ -2,6 +2,9 @@
 #include <Arduino.h>
 #include <IPAddress.h>
 
+
+const IPAddress INADDR_NONE(0,0,0,0);
+
 IPAddress::IPAddress()
 {
     memset(_address, 0, sizeof(_address));

--- a/hardware/lm4f/cores/lm4f/IPAddress.h
+++ b/hardware/lm4f/cores/lm4f/IPAddress.h
@@ -70,5 +70,7 @@ public:
     friend class DNSClient;
 };
 
-const IPAddress INADDR_NONE(0,0,0,0);
+extern const IPAddress INADDR_NONE;
+
+
 #endif

--- a/hardware/msp430/cores/msp430/IPAddress.cpp
+++ b/hardware/msp430/cores/msp430/IPAddress.cpp
@@ -2,6 +2,9 @@
 #include <Arduino.h>
 #include <IPAddress.h>
 
+
+const IPAddress INADDR_NONE(0,0,0,0);
+
 IPAddress::IPAddress()
 {
     memset(_address, 0, sizeof(_address));

--- a/hardware/msp430/cores/msp430/IPAddress.h
+++ b/hardware/msp430/cores/msp430/IPAddress.h
@@ -70,7 +70,7 @@ public:
     friend class DNSClient;
 };
 
-const IPAddress INADDR_NONE(0,0,0,0);
+extern const IPAddress INADDR_NONE;
 
 
 #endif

--- a/hardware/msp430/libraries/WiFi/utility/driver.c
+++ b/hardware/msp430/libraries/WiFi/utility/driver.c
@@ -102,6 +102,9 @@ typedef struct
     UINT8 AsyncRespBuf[SL_ASYNC_MAX_MSG_LEN];
 }_SlStatMem_t;
 
+#ifdef __MSP430_HAS_FRAM__
+__attribute__((section(".text")))
+#endif
 _SlStatMem_t g_StatMem;
 #endif
 


### PR DESCRIPTION
IPAddress and MACAddress currently declare their INADDR_NONE and MACADDR_NONE in their header file, which results in several instances of the object being declared without any real benefit.  Trim that down so it's a single "const IPAddress INADDR_NONE(0,0,0,0);" and likewise for MACADDR_NONE in the .cpp files, with an "extern const IPAddress INADDR_NONE;" in the header instead.  Seems to trim a lot from the sketch (230bytes from the MACADDR_NONE change alone with ScanNetworks on the FR5969).

Also, going to move the g_StatMem buffer in WiFi/utility/driver.c to FRAM for the MSP430 platform.
