### PR TITLE
CC3200 C++ constructors run before GPIO, timer init

### DIFF
--- a/hardware/cc3200/cores/cc3200/main.cpp
+++ b/hardware/cc3200/cores/cc3200/main.cpp
@@ -10,7 +10,11 @@
 
 extern void (* const g_pfnVectors[])(void);
 
-int main(void)
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void _init(void)
 {
 	IntVTableBaseSet((unsigned long)&g_pfnVectors[0]);
 
@@ -24,7 +28,14 @@ int main(void)
 	MAP_SysTickIntEnable();
 	MAP_SysTickPeriodSet(F_CPU / 1000);
 	MAP_SysTickEnable();
+}
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+int main(void)
+{
 	setup();
 
 	for (;;) {

--- a/hardware/cc3200/cores/cc3200/startup_gcc.c
+++ b/hardware/cc3200/cores/cc3200/startup_gcc.c
@@ -97,6 +97,7 @@ extern void SysTickIntHandler(void);
 // The entry point for the application.
 //
 //*****************************************************************************
+extern void _init(void);
 extern int main(void);
 
 
@@ -266,6 +267,12 @@ ResetISR(void)
           "        strlt   r2, [r0], #4\n"
           "        blt     zero_loop");
     
+
+    //
+    // Call Energia hardware init routine (timers, peripheral module clocks)
+    //
+    _init();
+
     //
     // call any global c++ ctors
     //


### PR DESCRIPTION
This is an issue that was fixed on the Tiva/Stellaris platform a while back but seems to exist on cc3200.  Normally it's discouraged to put any hardware init routines inside the C++ constructor of a library, but unfortunately it does happen, and the Arduino AVR platform often suffers no ill effects from it.  However on the ARM platforms, commands such as pinMode() and digitalWrite() inside a C++ constructor will cause the CPU to crash in FaultISR() due to an attempt to hit a GPIO peripheral which has not had its peripheral clock activated yet.

This pull-request breaks out the peripheral init & timer init into a separate "_init()" function and modifies ResetISR() to execute that before C++ ctors.
