### PR TITLE
config() to set Static IP Address fails without error; Does not revert to DHCP when removed.

### DIFF
--- a/hardware/cc3200/libraries/WiFi/WiFi.cpp
+++ b/hardware/cc3200/libraries/WiFi/WiFi.cpp
@@ -190,6 +190,20 @@ char* WiFiClass::firmwareVersion()
    return fwVersion;
 }
 
+void WiFiClass::setIpDefaults()
+{
+    //
+    // If ip addess configuration was not set using config(),
+    // set IP to DHCP.
+    // Only check for IP address since without the IP address
+    // being set, static IP configuration is useless?
+    //
+    if(local_IP == 0) {
+        unsigned char val = 1;
+        sl_NetCfgSet(SL_IPV4_STA_P2P_CL_DHCP_ENABLE,1,1,&val);
+    }
+}
+
 //--tested, working--//
 int WiFiClass::begin(char* ssid)
 {
@@ -202,7 +216,7 @@ int WiFiClass::begin(char* ssid)
         delay(500);
         return status();
     }
- 
+
     //
     //initialize the simplelink driver and make sure it was a success
     //
@@ -210,7 +224,12 @@ int WiFiClass::begin(char* ssid)
     if (!init_success) {
         return WL_CONNECT_FAILED;
     }
-    
+
+    //
+    // Set IP address configuration to DHCP if needed
+    //
+    setIpDefaults();
+
     sl_WlanPolicySet(SL_POLICY_CONNECTION , SL_CONNECTION_POLICY(1,1,0,0,0), 0, 0);
 
     //
@@ -263,6 +282,11 @@ int WiFiClass::begin(char* ssid, uint8_t key_idx, char* key)
         return WL_CONNECT_FAILED;
     }
     
+    //
+    // Set IP address configuration to DHCP if needed
+    //
+    setIpDefaults();
+
     sl_WlanPolicySet(SL_POLICY_CONNECTION , SL_CONNECTION_POLICY(1,1,0,0,0), 0, 0);
 
     //
@@ -308,14 +332,20 @@ int WiFiClass::begin(char* ssid, char *passphrase)
         delay(500);
         return status();
     }
+
     //
-    //initialize the simplelink driver and make sure it was a success
+    // Set IP address configuration to DHCP if needed
     //
     bool init_success = WiFiClass::init();
     if (!init_success) {
         return WL_CONNECT_FAILED;
     }
 
+    setIpDefaults();
+
+    //
+    //initialize the simplelink driver and make sure it was a success
+    //
     sl_WlanPolicySet(SL_POLICY_CONNECTION , SL_CONNECTION_POLICY(1,1,0,0,0), 0, 0);
 
     //
@@ -420,6 +450,13 @@ void WiFiClass::config(IPAddress local_ip)
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -431,7 +468,7 @@ void WiFiClass::config(IPAddress local_ip)
     //Assign new ip address to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
 }
 
@@ -440,6 +477,13 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server)
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -451,8 +495,8 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server)
     //Assign new ip address and new dns server to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
-    config.ipV4DnsServer = (uint32_t)dns_server;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
+    config.ipV4DnsServer = sl_Ntohl((uint32_t)dns_server);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
     
 }
@@ -462,6 +506,13 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -473,9 +524,9 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     //Assign new ip address and new dns server to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
-    config.ipV4DnsServer = (uint32_t)dns_server;
-    config.ipV4Gateway = (uint32_t)gateway;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
+    config.ipV4DnsServer = sl_Ntohl((uint32_t)dns_server);
+    config.ipV4Gateway = sl_Ntohl((uint32_t)gateway);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
     
 }
@@ -485,6 +536,13 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -496,10 +554,10 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     //Assign new ip address and new dns server to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
-    config.ipV4DnsServer = (uint32_t)dns_server;
-    config.ipV4Gateway = (uint32_t)gateway;
-    config.ipV4Mask = (uint32_t)subnet;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
+    config.ipV4DnsServer = sl_Ntohl((uint32_t)dns_server);
+    config.ipV4Gateway = sl_Ntohl((uint32_t)gateway);
+    config.ipV4Mask = sl_Ntohl((uint32_t)subnet);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
     
 }
@@ -563,7 +621,7 @@ uint8_t* WiFiClass::macAddress(uint8_t* mac)
     uint8_t macTemp[6];
     uint8_t macLength = 6;
     sl_NetCfgGet(SL_MAC_ADDRESS_GET, NULL, &macLength, (unsigned char *)macTemp);
-    
+
     //
     //All the arduino examples return the mac address reverse from simplelink
     //
@@ -585,8 +643,16 @@ IPAddress WiFiClass::localIP()
     //is critical. The IP is "written" into the buffer to avoid memory errors
     //
     _SlNonOsMainLoopTask();
+
+    _NetCfgIpV4Args_t config = {0};
+    unsigned char len = sizeof(_NetCfgIpV4Args_t);
+    sl_NetCfgGet(SL_IPV4_STA_P2P_CL_GET_INFO, NULL, &len, (unsigned char*)&config);
+
+    //
+    //change the uint32_t IP to the IPAddress class and return
+    //
     IPAddress retIP(0,0,0,0);
-    retIP = sl_Htonl(local_IP);
+    retIP = sl_Htonl(config.ipV4);
     return retIP;
 }
 

--- a/hardware/cc3200/libraries/WiFi/WiFi.h
+++ b/hardware/cc3200/libraries/WiFi/WiFi.h
@@ -324,6 +324,12 @@ public:
      */
     boolean setDateTime(uint16_t month, uint16_t day, uint16_t year, uint16_t hour, uint16_t minute, uint16_t second);
 
+    /*
+     * Set the ip configuration to DHCP if config(...) was not called before WiFi.begin().
+     * This will take care of setting DHCP as default network configuration
+     * if the prvious Sketch set the network to static.
+     */
+    void setIpDefaults();
 
     friend class WiFiClient;
     friend class WiFiServer;

--- a/hardware/lm4f/libraries/WiFi/WiFi.cpp
+++ b/hardware/lm4f/libraries/WiFi/WiFi.cpp
@@ -207,6 +207,20 @@ char* WiFiClass::firmwareVersion()
    return fwVersion;
 }
 
+void WiFiClass::setIpDefaults()
+{
+    //
+    // If ip addess configuration was not set using config(),
+    // set IP to DHCP.
+    // Only check for IP address since without the IP address
+    // being set, static IP configuration is useless?
+    //
+    if(local_IP == 0) {
+        unsigned char val = 1;
+        sl_NetCfgSet(SL_IPV4_STA_P2P_CL_DHCP_ENABLE,1,1,&val);
+    }
+}
+
 //--tested, working--//
 int WiFiClass::begin(char* ssid)
 {
@@ -219,7 +233,7 @@ int WiFiClass::begin(char* ssid)
         delay(500);
         return status();
     }
- 
+
     //
     //initialize the simplelink driver and make sure it was a success
     //
@@ -227,7 +241,12 @@ int WiFiClass::begin(char* ssid)
     if (!init_success) {
         return WL_CONNECT_FAILED;
     }
-    
+
+    //
+    // Set IP address configuration to DHCP if needed
+    //
+    setIpDefaults();
+
     sl_WlanPolicySet(SL_POLICY_CONNECTION , SL_CONNECTION_POLICY(1,1,0,0,0), 0, 0);
 
     //
@@ -280,6 +299,11 @@ int WiFiClass::begin(char* ssid, uint8_t key_idx, char* key)
         return WL_CONNECT_FAILED;
     }
     
+    //
+    // Set IP address configuration to DHCP if needed
+    //
+    setIpDefaults();
+
     sl_WlanPolicySet(SL_POLICY_CONNECTION , SL_CONNECTION_POLICY(1,1,0,0,0), 0, 0);
 
     //
@@ -325,14 +349,20 @@ int WiFiClass::begin(char* ssid, char *passphrase)
         delay(500);
         return status();
     }
+
     //
-    //initialize the simplelink driver and make sure it was a success
+    // Set IP address configuration to DHCP if needed
     //
     bool init_success = WiFiClass::init();
     if (!init_success) {
         return WL_CONNECT_FAILED;
     }
 
+    setIpDefaults();
+
+    //
+    //initialize the simplelink driver and make sure it was a success
+    //
     sl_WlanPolicySet(SL_POLICY_CONNECTION , SL_CONNECTION_POLICY(1,1,0,0,0), 0, 0);
 
     //
@@ -437,6 +467,13 @@ void WiFiClass::config(IPAddress local_ip)
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -448,7 +485,7 @@ void WiFiClass::config(IPAddress local_ip)
     //Assign new ip address to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
 }
 
@@ -457,6 +494,13 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server)
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -468,8 +512,8 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server)
     //Assign new ip address and new dns server to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
-    config.ipV4DnsServer = (uint32_t)dns_server;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
+    config.ipV4DnsServer = sl_Ntohl((uint32_t)dns_server);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
     
 }
@@ -479,6 +523,13 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -490,9 +541,9 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     //Assign new ip address and new dns server to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
-    config.ipV4DnsServer = (uint32_t)dns_server;
-    config.ipV4Gateway = (uint32_t)gateway;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
+    config.ipV4DnsServer = sl_Ntohl((uint32_t)dns_server);
+    config.ipV4Gateway = sl_Ntohl((uint32_t)gateway);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
     
 }
@@ -502,6 +553,13 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -513,10 +571,10 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     //Assign new ip address and new dns server to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
-    config.ipV4DnsServer = (uint32_t)dns_server;
-    config.ipV4Gateway = (uint32_t)gateway;
-    config.ipV4Mask = (uint32_t)subnet;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
+    config.ipV4DnsServer = sl_Ntohl((uint32_t)dns_server);
+    config.ipV4Gateway = sl_Ntohl((uint32_t)gateway);
+    config.ipV4Mask = sl_Ntohl((uint32_t)subnet);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
     
 }
@@ -580,7 +638,7 @@ uint8_t* WiFiClass::macAddress(uint8_t* mac)
     uint8_t macTemp[6];
     uint8_t macLength = 6;
     sl_NetCfgGet(SL_MAC_ADDRESS_GET, NULL, &macLength, (unsigned char *)macTemp);
-    
+
     //
     //All the arduino examples return the mac address reverse from simplelink
     //
@@ -602,8 +660,16 @@ IPAddress WiFiClass::localIP()
     //is critical. The IP is "written" into the buffer to avoid memory errors
     //
     _SlNonOsMainLoopTask();
+
+    _NetCfgIpV4Args_t config = {0};
+    unsigned char len = sizeof(_NetCfgIpV4Args_t);
+    sl_NetCfgGet(SL_IPV4_STA_P2P_CL_GET_INFO, NULL, &len, (unsigned char*)&config);
+
+    //
+    //change the uint32_t IP to the IPAddress class and return
+    //
     IPAddress retIP(0,0,0,0);
-    retIP = sl_Htonl(local_IP);
+    retIP = sl_Htonl(config.ipV4);
     return retIP;
 }
 

--- a/hardware/lm4f/libraries/WiFi/WiFi.h
+++ b/hardware/lm4f/libraries/WiFi/WiFi.h
@@ -335,6 +335,12 @@ public:
      */
     boolean setDateTime(uint16_t month, uint16_t day, uint16_t year, uint16_t hour, uint16_t minute, uint16_t second);
 
+    /*
+     * Set the ip configuration to DHCP if config(...) was not called before WiFi.begin().
+     * This will take care of setting DHCP as default network configuration
+     * if the prvious Sketch set the network to static.
+     */
+    void setIpDefaults();
 
     friend class WiFiClient;
     friend class WiFiServer;

--- a/hardware/msp430/libraries/WiFi/WiFi.cpp
+++ b/hardware/msp430/libraries/WiFi/WiFi.cpp
@@ -213,6 +213,20 @@ char* WiFiClass::firmwareVersion()
    return fwVersion;
 }
 
+void WiFiClass::setIpDefaults()
+{
+    //
+    // If ip addess configuration was not set using config(),
+    // set IP to DHCP.
+    // Only check for IP address since without the IP address
+    // being set, static IP configuration is useless?
+    //
+    if(local_IP == 0) {
+        unsigned char val = 1;
+        sl_NetCfgSet(SL_IPV4_STA_P2P_CL_DHCP_ENABLE,1,1,&val);
+    }
+}
+
 //--tested, working--//
 int WiFiClass::begin(char* ssid)
 {
@@ -225,7 +239,7 @@ int WiFiClass::begin(char* ssid)
         delay(500);
         return status();
     }
- 
+
     //
     //initialize the simplelink driver and make sure it was a success
     //
@@ -233,7 +247,12 @@ int WiFiClass::begin(char* ssid)
     if (!init_success) {
         return WL_CONNECT_FAILED;
     }
-    
+
+    //
+    // Set IP address configuration to DHCP if needed
+    //
+    setIpDefaults();
+
     sl_WlanPolicySet(SL_POLICY_CONNECTION , SL_CONNECTION_POLICY(1,1,0,0,0), 0, 0);
 
     //
@@ -286,6 +305,11 @@ int WiFiClass::begin(char* ssid, uint8_t key_idx, char* key)
         return WL_CONNECT_FAILED;
     }
     
+    //
+    // Set IP address configuration to DHCP if needed
+    //
+    setIpDefaults();
+
     sl_WlanPolicySet(SL_POLICY_CONNECTION , SL_CONNECTION_POLICY(1,1,0,0,0), 0, 0);
 
     //
@@ -331,14 +355,20 @@ int WiFiClass::begin(char* ssid, char *passphrase)
         delay(500);
         return status();
     }
+
     //
-    //initialize the simplelink driver and make sure it was a success
+    // Set IP address configuration to DHCP if needed
     //
     bool init_success = WiFiClass::init();
     if (!init_success) {
         return WL_CONNECT_FAILED;
     }
 
+    setIpDefaults();
+
+    //
+    //initialize the simplelink driver and make sure it was a success
+    //
     sl_WlanPolicySet(SL_POLICY_CONNECTION , SL_CONNECTION_POLICY(1,1,0,0,0), 0, 0);
 
     //
@@ -443,6 +473,13 @@ void WiFiClass::config(IPAddress local_ip)
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -454,7 +491,7 @@ void WiFiClass::config(IPAddress local_ip)
     //Assign new ip address to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
 }
 
@@ -463,6 +500,13 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server)
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -474,8 +518,8 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server)
     //Assign new ip address and new dns server to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
-    config.ipV4DnsServer = (uint32_t)dns_server;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
+    config.ipV4DnsServer = sl_Ntohl((uint32_t)dns_server);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
     
 }
@@ -485,6 +529,13 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -496,9 +547,9 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     //Assign new ip address and new dns server to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
-    config.ipV4DnsServer = (uint32_t)dns_server;
-    config.ipV4Gateway = (uint32_t)gateway;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
+    config.ipV4DnsServer = sl_Ntohl((uint32_t)dns_server);
+    config.ipV4Gateway = sl_Ntohl((uint32_t)gateway);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
     
 }
@@ -508,6 +559,13 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     if (!_initialized) {
         init();
     }
+
+    //
+    // Set the local_IP indicating that the network
+    // is configured for static IP.
+    //
+    local_IP = local_ip;
+
     //
     //get current configuration
     //
@@ -519,10 +577,10 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gatew
     //Assign new ip address and new dns server to current config
     //and use netcfgset to set the new configuration in memory
     //
-    config.ipV4 = (uint32_t)local_ip;
-    config.ipV4DnsServer = (uint32_t)dns_server;
-    config.ipV4Gateway = (uint32_t)gateway;
-    config.ipV4Mask = (uint32_t)subnet;
+    config.ipV4 = sl_Ntohl((uint32_t)local_ip);
+    config.ipV4DnsServer = sl_Ntohl((uint32_t)dns_server);
+    config.ipV4Gateway = sl_Ntohl((uint32_t)gateway);
+    config.ipV4Mask = sl_Ntohl((uint32_t)subnet);
     sl_NetCfgSet(SL_IPV4_STA_P2P_CL_STATIC_ENABLE, 1, sizeof(_NetCfgIpV4Args_t), (unsigned char*)&config);
     
 }
@@ -586,7 +644,7 @@ uint8_t* WiFiClass::macAddress(uint8_t* mac)
     uint8_t macTemp[6];
     uint8_t macLength = 6;
     sl_NetCfgGet(SL_MAC_ADDRESS_GET, NULL, &macLength, (unsigned char *)macTemp);
-    
+
     //
     //All the arduino examples return the mac address reverse from simplelink
     //
@@ -608,8 +666,16 @@ IPAddress WiFiClass::localIP()
     //is critical. The IP is "written" into the buffer to avoid memory errors
     //
     _SlNonOsMainLoopTask();
+
+    _NetCfgIpV4Args_t config = {0};
+    unsigned char len = sizeof(_NetCfgIpV4Args_t);
+    sl_NetCfgGet(SL_IPV4_STA_P2P_CL_GET_INFO, NULL, &len, (unsigned char*)&config);
+
+    //
+    //change the uint32_t IP to the IPAddress class and return
+    //
     IPAddress retIP(0,0,0,0);
-    retIP = sl_Htonl(local_IP);
+    retIP = sl_Htonl(config.ipV4);
     return retIP;
 }
 

--- a/hardware/msp430/libraries/WiFi/WiFi.h
+++ b/hardware/msp430/libraries/WiFi/WiFi.h
@@ -335,6 +335,12 @@ public:
      */
     boolean setDateTime(uint16_t month, uint16_t day, uint16_t year, uint16_t hour, uint16_t minute, uint16_t second);
 
+    /*
+     * Set the ip configuration to DHCP if config(...) was not called before WiFi.begin().
+     * This will take care of setting DHCP as default network configuration
+     * if the prvious Sketch set the network to static.
+     */
+    void setIpDefaults();
 
     friend class WiFiClient;
     friend class WiFiServer;


### PR DESCRIPTION
Following http://energia.nu/reference/wifi/wifi_config/ to use a static IP address on a CC320, the IP address reported was the reverse of what was set (177.0.168.192 instead of 192.168.0.177), and neither responded. Setting the reverse had even worse results (0.0.0.0).

Running a normal sketch that does not use config() reports keeping the same IP as when config() was last used, and will not return to DHCP use.
