### PR TITLE
Fixed mismatches in filenames in C2000 source files

### DIFF
--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_Adc.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_Adc.c
@@ -12,7 +12,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 #define ADC_usDELAY  1000L
 

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_Comp.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_Comp.c
@@ -12,7 +12,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 //---------------------------------------------------------------------------
 // InitComp:

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_CpuTimers.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_CpuTimers.c
@@ -18,7 +18,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 struct CPUTIMER_VARS CpuTimer0;
 

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_DefaultIsr.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_DefaultIsr.c
@@ -22,7 +22,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 // Connected to INT13 of CPU (use MINT13 mask):
 interrupt void INT13_ISR(void)     // INT13 or CPU-Timer1

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_ECap.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_ECap.c
@@ -12,7 +12,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 //---------------------------------------------------------------------------
 // InitECap:

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_EPwm.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_EPwm.c
@@ -12,7 +12,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 //---------------------------------------------------------------------------
 // InitEPwm:

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_Gpio.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_Gpio.c
@@ -12,7 +12,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 //---------------------------------------------------------------------------
 // InitGpio:

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_I2C.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_I2C.c
@@ -12,7 +12,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 //---------------------------------------------------------------------------
 // InitI2C:

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_OscComp.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_OscComp.c
@@ -27,7 +27,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 
 // Useful definitions

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_PieCtrl.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_PieCtrl.c
@@ -12,7 +12,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 //---------------------------------------------------------------------------
 // InitPieCtrl: 

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_PieVect.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_PieVect.c
@@ -12,7 +12,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 const struct PIE_VECT_TABLE PieVectTableInit = {
 

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_SWPrioritizedDefaultIsr.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_SWPrioritizedDefaultIsr.c
@@ -13,7 +13,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 #include "f2802x_common/include/F2802x_SWPrioritizedIsrLevels.h"
 
 // Connected to INT13 of CPU (use MINT13 mask):

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_SWPrioritizedPieVect.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_SWPrioritizedPieVect.c
@@ -15,8 +15,8 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
-#include "f2802x_common/include/f2802x_swprioritizedisrlevels.h"
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_SWPrioritizedIsrLevels.h"
 
 const struct PIE_VECT_TABLE PieVectTableInit = {
 

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_Sci.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_Sci.c
@@ -12,7 +12,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 //---------------------------------------------------------------------------
 // InitSci:

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_Spi.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_Spi.c
@@ -12,7 +12,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 //---------------------------------------------------------------------------
 // InitSPI:

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_SysCtrl.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_SysCtrl.c
@@ -16,7 +16,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 // Functions that will be run from RAM need to be assigned to
 // a different section.  This section will then be mapped to a load and

--- a/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_TempSensorConv.c
+++ b/hardware/c2000/cores/c2000/f2802x_common/source/F2802x_TempSensorConv.c
@@ -28,7 +28,7 @@
 //###########################################################################
 
 #include "F2802x_Device.h"     // Headerfile Include File
-#include "f2802x_common/include/f2802x_examples.h"   // Examples Include File
+#include "f2802x_common/include/F2802x_Examples.h"   // Examples Include File
 
 // Useful definitions
   #define FP_SCALE 32768       //Scale factor for Q15 fixed point numbers (2^15)

--- a/hardware/c2000/cores/c2000/wiring_analog.c
+++ b/hardware/c2000/cores/c2000/wiring_analog.c
@@ -33,7 +33,7 @@
 #include "pins_energia.h"
 
 #ifdef TMS320F28027
-#include "f2802x_common/include/f2802x_epwm_defines.h"
+#include "f2802x_common/include/F2802x_EPwm_defines.h"
 #elif defined(TMS320F28069)
 #include "F2806x_common/include/F2806x_EPwm_defines.h"
 #endif


### PR DESCRIPTION
This is a fix for issue with letter case in names of include files mentioned in comment to issue #531