### PR TITLE
I2C timeout resolving hang when slave not present

### DIFF
--- a/hardware/lm4f/libraries/Wire/Wire.cpp
+++ b/hardware/lm4f/libraries/Wire/Wire.cpp
@@ -239,8 +239,7 @@ uint8_t TwoWire::i2cModule = NOT_ACTIVE;
 uint8_t TwoWire::slaveAddress = 0;
 
 uint32_t TwoWire::local_timeout = 0;
-uint8_t TwoWire::timeout_enabled = 0x00;
-uint32_t TwoWire::timeout = 100; // default ms timeout
+uint32_t TwoWire::timeout = 0; // 0 is disabled
 // Constructors ////////////////////////////////////////////////////////////////
 
 TwoWire::TwoWire()
@@ -267,7 +266,7 @@ uint8_t TwoWire::getRxData(unsigned long cmd) {
 	HWREG(MASTER_BASE + I2C_O_MCS) = cmd;
 	local_timeout = millis() + timeout;
     while(ROM_I2CMasterBusy(MASTER_BASE)){
-		if(local_timeout<millis()&timeout_enabled){
+		if(local_timeout<millis()&timeout>0){
 			return(4);
 		}
 	}
@@ -291,7 +290,7 @@ uint8_t TwoWire::sendTxData(unsigned long cmd, uint8_t data) {
     HWREG(MASTER_BASE + I2C_O_MCS) = cmd;
     local_timeout = millis() + timeout;
     while(ROM_I2CMasterBusy(MASTER_BASE)){
-		if(local_timeout<millis()&timeout_enabled){
+		if(local_timeout<millis()&timeout>0){
 			return(4);
 		}
 	}
@@ -487,13 +486,13 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
   //Wait for any previous transaction to complete
   local_timeout = millis() + timeout;
 	while(ROM_I2CMasterBusBusy(MASTER_BASE)){
-		if(local_timeout<millis()&timeout_enabled){
+		if(local_timeout<millis()&timeout>0){
 			return(4);
 		}
 	};
   local_timeout = millis() + timeout;
     while(ROM_I2CMasterBusy(MASTER_BASE)){
-		if(local_timeout<millis()&timeout_enabled){
+		if(local_timeout<millis()&timeout>0){
 			return(4);
 		}
 	}
@@ -503,7 +502,7 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
 
   local_timeout = millis() + timeout;
     while(ROM_I2CMasterBusy(MASTER_BASE)){
-		if(local_timeout<millis()&timeout_enabled){
+		if(local_timeout<millis()&timeout>0){
 			return(4);
 		}
 	}
@@ -719,17 +718,8 @@ void TwoWire::setModule(unsigned long _i2cModule)
 
 void TwoWire::setTimeout(unsigned int user_timeout)
 {
-	if(user_timeout>0)
-	{
-		timeout = user_timeout;
-		timeout_enabled = 0xff; //enable timeout
-	}
-	else
-	{
-		timeout_enabled = 0; //disable timeout
-	}
+	timeout = user_timeout;
 }
 
 //Preinstantiate Object
 TwoWire Wire;
-po

--- a/hardware/lm4f/libraries/Wire/Wire.h
+++ b/hardware/lm4f/libraries/Wire/Wire.h
@@ -31,7 +31,6 @@ class TwoWire : public Stream
 		static uint8_t slaveAddress;
 		
 		static uint32_t local_timeout;
-		static uint8_t timeout_enabled;
 		static uint32_t timeout;
 
 		static uint8_t transmitting;

--- a/hardware/lm4f/libraries/Wire/Wire.h
+++ b/hardware/lm4f/libraries/Wire/Wire.h
@@ -29,6 +29,10 @@ class TwoWire : public Stream
 
 		static uint8_t i2cModule;
 		static uint8_t slaveAddress;
+		
+		static uint32_t local_timeout;
+		static uint8_t timeout_enabled;
+		static uint32_t timeout;
 
 		static uint8_t transmitting;
 		static uint8_t currentState;
@@ -74,6 +78,7 @@ class TwoWire : public Stream
 		//Stellarpad-specific functions
 		void I2CIntHandler(void);
 		void setModule(unsigned long);
+		void setTimeout(unsigned int);
 
 };
 


### PR DESCRIPTION
I have introduced timeout for I2C to resolve it hanging if the slave is not present or for example pull-ups are not present. An error is returned. You do Wire.setTimeout(value) to set the timeout, even after begin. If you set timeout to be greater then 0 it is enabled, otherwise it is disabled, backwards compatible.

This change is introduced as StellarPad specific, but it should work for other hardwares as well.