### PR TITLE
expose destination IP of UDP packets received 

### DIFF
--- a/hardware/lm4f/libraries/Ethernet/EthernetUdp.cpp
+++ b/hardware/lm4f/libraries/Ethernet/EthernetUdp.cpp
@@ -26,6 +26,7 @@ void EthernetUDP::do_recv(void *arg, struct udp_pcb *upcb, struct pbuf *p, struc
 	/* Record the IP address and port the pacekt was received from */
 	udp->packets[udp->rear].remoteIP = IPAddress(addr->addr);
 	udp->packets[udp->rear].remotePort = port;
+	udp->packets[udp->rear].destIP = IPAddress(ip_current_dest_addr()->addr);
 
 	/* Advance the rear of the queue */
 	udp->rear++;
@@ -159,6 +160,7 @@ int EthernetUDP::parsePacket()
 		_p = NULL;
 		_remotePort = 0;
 		_remoteIP = IPAddress(IPADDR_NONE);
+		_destIP = IPAddress(IPADDR_NONE);
 	}
 
 	/* No more packets in the queue */
@@ -170,6 +172,7 @@ int EthernetUDP::parsePacket()
 	_p = packets[front].p;
 	_remoteIP = packets[front].remoteIP;
 	_remotePort = packets[front].remotePort;
+	_destIP = packets[front].destIP;
 
 	count--;
 

--- a/hardware/lm4f/libraries/Ethernet/EthernetUdp.h
+++ b/hardware/lm4f/libraries/Ethernet/EthernetUdp.h
@@ -11,6 +11,7 @@ struct packet {
 	struct pbuf *p;
 	IPAddress remoteIP;
 	uint16_t remotePort;
+	IPAddress destIP;
 };
 
 class EthernetUDP : public UDP {
@@ -26,6 +27,7 @@ private:
 	/* IP and port filled in when receiving a packet */
 	IPAddress _remoteIP;
 	uint16_t _remotePort;
+	IPAddress _destIP;
 	/* pbuf, pcb, IP and port used when acting as a client */
 	struct pbuf *_sendTop;
 	struct udp_pcb *_sendToPcb;
@@ -58,6 +60,7 @@ public:
 
 	virtual IPAddress remoteIP() { return _remoteIP; };
 	virtual uint16_t remotePort() { return _remotePort; };
+	virtual IPAddress destIP() { return _destIP; };
 };
 
 #endif


### PR DESCRIPTION
I've added this function to allow for filtering of packets based on IP as well as content. My current project requires me to have all packets come in on one port, but some packets can't be accepted if its destination address is the broadcast address.