### PR TITLE
Broadcast UDP packets can't be sent or received when starting Ethernet with fixed IP

### DIFF
--- a/hardware/lm4f/libraries/Ethernet/Ethernet.h
+++ b/hardware/lm4f/libraries/Ethernet/Ethernet.h
@@ -13,9 +13,9 @@
 #define CLASS_A 0x0
 #define CLASS_B 0x2
 #define CLASS_C 0x6
-const IPAddress CLASS_A_SUBNET(255, 255, 255, 0);
+const IPAddress CLASS_A_SUBNET(255, 0, 0, 0);
 const IPAddress CLASS_B_SUBNET(255, 255, 0, 0);
-const IPAddress CLASS_C_SUBNET(255, 0, 0, 0);
+const IPAddress CLASS_C_SUBNET(255, 255, 255, 0);
 
 class EthernetClass {
 private:


### PR DESCRIPTION
Hello,

While fault finding trying to send broadcast UDP packets from the tiva c connected launchpad I noticed that packets send to the broadcast address for my network (in my case 192.168.1.255) were not reaching any other computers on my network. Likewise any broadcast UDP packets sent out by computers on the network were being received by other computers but not by my tiva c.

Once I switched to obtaining my IP via DHCP when starting Ethernet, both sending and receiving broadcast packets worked.

This is quite an issue for me as my project needs to be able to use both. I've tried looking through the lwip code but haven't been able to come up with the cause or a solution.