### PR TITLE
msp430: fix comment about pin name for F5529 for timer

### DIFF
--- a/hardware/msp430/variants/launchpad_f5529/pins_energia.h
+++ b/hardware/msp430/variants/launchpad_f5529/pins_energia.h
@@ -316,7 +316,7 @@ const uint8_t digital_pin_to_timer[] = {
 	NOT_ON_TIMER, /* 11 - P8.1 */
 	T2A0,         /* 12 - P2.3 */
 	NOT_ON_TIMER, /* 13 - P2.6 */
-	NOT_ON_TIMER, /* 14 - P3.2 */
+	NOT_ON_TIMER, /* 14 - P3.1 */
 	NOT_ON_TIMER, /* 15 - P3.0 */
 	NOT_ON_TIMER, /* 16 - RST */
 	T0B2,         /* 17 - P7.4 */


### PR DESCRIPTION
Pin 14 on Launchpad F5529 is P3.1, not P3.2