### PR TITLE
msp430: twi: move interrupt handler for USCI_Bx to twi.c

### DIFF
--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -43,6 +43,10 @@
 #include "twi.h"
 #include "usci_isr_handler.h"
 
+#if defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__) || defined(__MSP430_HAS_EUSCI_B0__)
+static boolean still_asleep;  // Used to validate whether a user ISR has issued wakeup() inside LPM3/LPM4 sleep modes.
+#endif
+
 static volatile uint8_t twi_state;
 static volatile uint8_t twi_sendStop;           // should the transaction end with a stop
 static volatile uint8_t twi_inRepStart;         // in the middle of a repeated start
@@ -795,6 +799,42 @@ void i2c_state_isr(void)  // I2C Service
 		twi_state =  TWI_IDLE;
 	}
 }
+#endif
+
+#if defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
+#ifndef USE_USCI_B1
+__attribute__((interrupt(USCI_B0_VECTOR)))
+void USCIB0_ISR(void)
+{
+	still_asleep = stay_asleep;
+
+	/* USCI_B0 I2C state change interrupt. */
+	if ((UCB0CTL0 & UCMODE_3) == UCMODE_3 && (UCB0IFG & (UCALIFG | UCNACKIFG | UCSTTIFG | UCSTPIFG)) != 0)
+		i2c_state_isr();
+	/* USCI_B0 I2C TX RX interrupt. */
+	if ((UCB0CTL0 & UCMODE_3) == UCMODE_3 && (UCB0IFG & (UCTXIFG | UCRXIFG)) != 0)
+		i2c_txrx_isr();
+
+	if (still_asleep != stay_asleep)
+		__bic_SR_register_on_exit(LPM4_bits);
+}
+#else
+__attribute__((interrupt(USCI_B1_VECTOR)))
+void USCIB1_ISR(void)
+{
+	still_asleep = stay_asleep;
+
+	/* USCI_B1 I2C state change interrupt. */
+	if ((UCB1CTL0 & UCMODE_3) == UCMODE_3 && (UCB1IFG & (UCALIFG | UCNACKIFG | UCSTTIFG | UCSTPIFG)) != 0)
+		i2c_state_isr();
+	/* USCI_B1 I2C TX RX interrupt. */
+	if ((UCB1CTL0 & UCMODE_3) == UCMODE_3 && (UCB1IFG & (UCTXIFG | UCRXIFG)) != 0)
+		i2c_txrx_isr();
+
+	if (still_asleep != stay_asleep)
+		__bic_SR_register_on_exit(LPM4_bits);
+}
+#endif
 #endif
 
 #ifdef __MSP430_HAS_EUSCI_B0__

--- a/hardware/msp430/cores/msp430/usci_isr_handler.c
+++ b/hardware/msp430/cores/msp430/usci_isr_handler.c
@@ -1,6 +1,6 @@
 #include "Energia.h"
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_A0__) || defined(__MSP430_HAS_USCI_A1__) \
- || defined(__MSP430_HAS_EUSCI_A0__)|| defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__) 
+ || defined(__MSP430_HAS_EUSCI_A0__)
 #include "usci_isr_handler.h"
 /* This dummy function ensures that, when called from any module that 
  * is interested in having the USCIAB0TX_VECTOR and USCIAB0TX_VECTOR
@@ -60,41 +60,6 @@ void USCIA1_ISR(void)
 }
 #endif
 
-#if defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
-#ifndef USE_USCI_B1
-__attribute__((interrupt(USCI_B0_VECTOR)))
-void USCIB0_ISR(void)
-{
-	still_asleep = stay_asleep;
-
-	/* USCI_B0 I2C state change interrupt. */
-	if ((UCB0CTL0 & UCMODE_3) == UCMODE_3 && (UCB0IFG & (UCALIFG | UCNACKIFG | UCSTTIFG | UCSTPIFG)) != 0)
-		i2c_state_isr(); 
-	/* USCI_B0 I2C TX RX interrupt. */
-	if ((UCB0CTL0 & UCMODE_3) == UCMODE_3 && (UCB0IFG & (UCTXIFG | UCRXIFG)) != 0)
-		i2c_txrx_isr();
-
-	if (still_asleep != stay_asleep)
-		__bic_SR_register_on_exit(LPM4_bits);
-}
-#else
-__attribute__((interrupt(USCI_B1_VECTOR)))
-void USCIB1_ISR(void)
-{
-	still_asleep = stay_asleep;
-
-	/* USCI_B1 I2C state change interrupt. */
-	if ((UCB1CTL0 & UCMODE_3) == UCMODE_3 && (UCB1IFG & (UCALIFG | UCNACKIFG | UCSTTIFG | UCSTPIFG)) != 0)
-		i2c_state_isr(); 
-	/* USCI_B1 I2C TX RX interrupt. */
-	if ((UCB1CTL0 & UCMODE_3) == UCMODE_3 && (UCB1IFG & (UCTXIFG | UCRXIFG)) != 0)
-		i2c_txrx_isr();
-
-	if (still_asleep != stay_asleep)
-		__bic_SR_register_on_exit(LPM4_bits);
-}
-#endif
-#endif
 
 #endif //defined(__MSP430_HAS_USCI_A0__) || defined(__MSP430_HAS_USCI_A1__) || defined(__MSP430_HAS_EUSCI_A0__)
 
@@ -144,3 +109,4 @@ void USCIAB0RX_ISR(void)
 }
 #endif // __MSP430_HAS_USCI__
 #endif // entire file
+

--- a/hardware/msp430/cores/msp430/usci_isr_handler.h
+++ b/hardware/msp430/cores/msp430/usci_isr_handler.h
@@ -2,7 +2,7 @@
 #define usci_isr_handler_h
 
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_A0__) || defined(__MSP430_HAS_USCI_A1__) \
- || defined(__MSP430_HAS_EUSCI_A0__)|| defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__) 
+ || defined(__MSP430_HAS_EUSCI_A0__)
 
 typedef void CHardwareSerial;
 #ifdef __cplusplus


### PR DESCRIPTION
For the USCI module, it shares interrupt vector for
USCI_Ax and USCI_Bx, so the interrupt routine should still
be in usci_isr_handler.

But for USCI_B0 and USCI_B1, the interrupt handler can be
moved to twi.c. This is exactly the same way it is done
for the EUSCI_Bx module, it already has the interrupt
handler in twi.c