### PR TITLE
msp430: i2c, allow choosing which USCI_Bx module to use

### DIFF
--- a/hardware/msp430/cores/msp430/Wire.cpp
+++ b/hardware/msp430/cores/msp430/Wire.cpp
@@ -51,6 +51,7 @@ uint8_t TwoWire::txBufferLength = 0;
 uint8_t TwoWire::transmitting = 0;
 void (*TwoWire::user_onRequest)(void);
 void (*TwoWire::user_onReceive)(int);
+uint8_t TwoWire::i2cModule = 0;
 
 // Constructors ////////////////////////////////////////////////////////////////
 
@@ -68,7 +69,7 @@ void TwoWire::begin(void)
   txBufferIndex = 0;
   txBufferLength = 0;
 
-  twi_init();
+  twi_init(i2cModule);
 }
 
 void TwoWire::begin(uint8_t address)
@@ -299,6 +300,11 @@ void TwoWire::onReceive( void (*function)(int) )
 void TwoWire::onRequest( void (*function)(void) )
 {
   user_onRequest = function;
+}
+
+void TwoWire::setModule(unsigned long _i2cModule)
+{
+    i2cModule = _i2cModule;
 }
 
 // Preinstantiate Objects //////////////////////////////////////////////////////

--- a/hardware/msp430/cores/msp430/Wire.h
+++ b/hardware/msp430/cores/msp430/Wire.h
@@ -53,6 +53,8 @@ class TwoWire : public Stream
     static void (*user_onReceive)(int);
     static void onRequestService(void);
     static void onReceiveService(uint8_t*, int);
+
+    static uint8_t i2cModule;
   public:
     TwoWire();
     void begin();
@@ -86,6 +88,8 @@ class TwoWire : public Stream
     inline size_t write(unsigned int n) { return write((uint8_t)n); }
     inline size_t write(int n) { return write((uint8_t)n); }
     using Print::write;
+
+    void setModule(unsigned long);
 };
 
 extern TwoWire Wire;

--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -74,7 +74,7 @@ static uint8_t twi_my_addr;
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) \
  || defined(__MSP430_HAS_USCI_B1__)
 #ifndef USE_USCI_B1
-#define UCBxCTLW0     UCB0CTLW0 
+#define UCBxCTLW0     UCB0CTLW0
 #define UCBxCTL0      UCB0CTL0
 #define UCBxCTL1      UCB0CTL1
 #define UCBxCTL0      UCB0CTL0
@@ -685,7 +685,7 @@ void i2c_txrx_isr(void)  // RX/TX Service
 #endif
 		/* Master transmit mode */
 		if (twi_state == TWI_MTX) {
-			// if there is data to send, send it, otherwise stop 
+			// if there is data to send, send it, otherwise stop
 			if(twi_masterBufferIndex < twi_masterBufferLength){
 				// Copy data to output register and ack.
 				UCB0TXBUF = twi_masterBuffer[twi_masterBufferIndex++];
@@ -697,7 +697,7 @@ void i2c_txrx_isr(void)  // RX/TX Service
 					__bic_SR_register(LPM0_bits);
 				} else {
 					twi_inRepStart = true;  // we're gonna send the START
-					// don't enable the interrupt. We'll generate the start, but we 
+					// don't enable the interrupt. We'll generate the start, but we
 					// avoid handling the interrupt until we're in the next transaction,
 					// at the point where we would normally issue the start.
 					UCB0CTL1 |= UCTXSTT;
@@ -766,7 +766,7 @@ void i2c_state_isr(void)  // I2C Service
 			/* Request for txBuffer to be filled and length to be set. */
 			/* note: user must call twi_transmit(bytes, length) to do this */
 			twi_onSlaveTransmit();
-			/* If they didn't change buffer & length, initialize it 
+			/* If they didn't change buffer & length, initialize it
 			 * TODO: Is this right? Shouldn't we reply with a NACK if there is no data to send? */
 			if (0 == twi_txBufferLength) {
 				twi_txBufferLength = 1;
@@ -837,7 +837,7 @@ void USCI_B0_ISR(void)
         // leave slave receiver state
         twi_state = TWI_IDLE;
 		twi_error = TWI_ERROR_DATA_NACK;
-        __bic_SR_register_on_exit(CPUOFF); // Exit LPM0                 
+        __bic_SR_register_on_exit(CPUOFF); // Exit LPM0
       break;
     case USCI_I2C_UCSTTIFG:    // USCI I2C Mode: UCSTTIFG
 		UCB0IFG &= ~UCSTTIFG;
@@ -877,7 +877,7 @@ void USCI_B0_ISR(void)
 		 */
 		UCB0CTLW0 &= ~0x18;
 		
-		__bic_SR_register_on_exit(CPUOFF); // Exit LPM0                 
+		__bic_SR_register_on_exit(CPUOFF); // Exit LPM0
       break;
     case USCI_I2C_UCRXIFG3:    // USCI I2C Mode: UCRXIFG3
       break;
@@ -915,7 +915,7 @@ void USCI_B0_ISR(void)
     case USCI_I2C_UCTXIFG0:    // USCI I2C Mode: UCTXIFG0
 		UCB0IFG &= ~UCTXIFG;                  // Clear USCI_B0 TX int flag
 		if (twi_state == TWI_MTX) {      // Master receive mode
-			// if there is data to send, send it, otherwise stop 
+			// if there is data to send, send it, otherwise stop
 			if(twi_masterBufferIndex < twi_masterBufferLength){
 				// copy data to output register and ack
 				UCB0TXBUF = twi_masterBuffer[twi_masterBufferIndex++];                 // Transmit data at address PTxData
@@ -924,7 +924,7 @@ void USCI_B0_ISR(void)
 				UCB0CTLW0 |= UCTXSTP;                // Generate I2C stop condition
 			   else {
 				 twi_inRepStart = true;   // we're gonna send the START
-				 // don't enable the interrupt. We'll generate the start, but we 
+				 // don't enable the interrupt. We'll generate the start, but we
 				 // avoid handling the interrupt until we're in the next transaction,
 				 // at the point where we would normally issue the start.
 				 UCB0CTLW0 |= UCTXSTT;        

--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -77,7 +77,6 @@ static uint8_t twi_my_addr;
 #define UCBxCTLW0     UCB0CTLW0
 #define UCBxCTL0      UCB0CTL0
 #define UCBxCTL1      UCB0CTL1
-#define UCBxCTL0      UCB0CTL0
 #define UCBxBRW       UCB0BRW
 #define UCBxBR0       UCB0BR0
 #define UCBxBR1       UCB0BR1
@@ -98,7 +97,6 @@ static uint8_t twi_my_addr;
 #define UCBxCTLW0     UCB1CTLW0
 #define UCBxCTL0      UCB1CTL0
 #define UCBxCTL1      UCB1CTL1
-#define UCBxCTL0      UCB1CTL0
 #define UCBxBRW       UCB1BRW
 #define UCBxBR0       UCB1BR0
 #define UCBxBR1       UCB1BR1

--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -95,6 +95,10 @@ static uint8_t twi_my_addr;
 #define UCBxIV        UCB0IV
 #define UCBxI2COA     UCB0I2COA
 #define UCBxI2CSA     UCB0I2CSA
+#define TWISDAx       TWISDA
+#define TWISCLx       TWISCL
+#define TWISDA_SET_MODEx TWISDA_SET_MODE
+#define TWISCL_SET_MODEx TWISCL_SET_MODE
 #else
 #define UCBxCTLW0     UCB1CTLW0
 #define UCBxCTL0      UCB1CTL0
@@ -117,6 +121,10 @@ static uint8_t twi_my_addr;
 #define UCBxIV        UCB1IV
 #define UCBxI2COA     UCB1I2COA
 #define UCBxI2CSA     UCB1I2CSA
+#define TWISDAx       TWISDA1
+#define TWISCLx       TWISCL1
+#define TWISDA_SET_MODEx TWISDA_SET_MODE1
+#define TWISCL_SET_MODEx TWISCL_SET_MODE1
 #endif
 #endif
 
@@ -169,8 +177,8 @@ void twi_init(void)
     usci_isr_install();
 
     /* Set pins to I2C mode */
-    pinMode_int(TWISDA, TWISDA_SET_MODE);
-    pinMode_int(TWISCL, TWISCL_SET_MODE);
+    pinMode_int(TWISDAx, TWISDA_SET_MODEx);
+    pinMode_int(TWISCLx, TWISCL_SET_MODEx);
 
     //Disable the USCI module and clears the other bits of control register
     UCBxCTL1 = UCSWRST;

--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -56,6 +56,8 @@ static uint8_t twi_masterBuffer[TWI_BUFFER_LENGTH];
 static volatile uint8_t twi_masterBufferIndex;
 static uint8_t twi_masterBufferLength;
 
+static volatile uint8_t twi_error;
+
 static uint8_t twi_txBuffer[TWI_BUFFER_LENGTH];
 static volatile uint8_t twi_txBufferIndex;
 static volatile uint8_t twi_txBufferLength;
@@ -63,14 +65,9 @@ static volatile uint8_t twi_txBufferLength;
  || defined(__MSP430_HAS_USCI_B1__) || defined(__MSP430_HAS_EUSCI_B0__)
 static uint8_t twi_rxBuffer[TWI_BUFFER_LENGTH];
 static volatile uint8_t twi_rxBufferIndex;
-#endif
-
-static volatile uint8_t twi_error;
-
-#if defined(__MSP430_HAS_USI__)
+#elif defined(__MSP430_HAS_USI__)
 static uint8_t twi_slarw;
 static uint8_t twi_my_addr;
-
 #endif
 
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) \
@@ -130,12 +127,6 @@ static uint8_t twi_my_addr;
 #endif
 #endif
 
-#if defined(__MSP430_HAS_USCI__)
-#endif
-
-#if defined(__MSP430_HAS_EUSCI_B0__)
-#endif
-
 /*
  * Function twi_init
  * Desc     readys twi pins and sets twi bitrate
@@ -150,7 +141,6 @@ void twi_init(void)
 	twi_inRepStart = false;
 
 #if defined(__MSP430_HAS_USI__)
-
 	/* 100 KHz for all */
 #if (F_CPU >= 16000000L) || (F_CPU >= 12000000L)
 	USICKCTL = USIDIV_7;
@@ -171,9 +161,7 @@ void twi_init(void)
 	USICTL0 &= ~USISWRST;
 	/* Counter interrupt enable */
 	USICTL1 |= USIIE;
-#endif
-
-#if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
+#elif defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
     /* Calling this dummy function prevents the linker
      * from stripping the USCI interupt vectors.*/ 
     usci_isr_install();
@@ -213,9 +201,7 @@ void twi_init(void)
     /* Set I2C state change interrupt mask and TX/RX interrupts */
     UCBxIE |= (UCALIE|UCNACKIE|UCSTTIE|UCSTPIE|UCRXIE|UCTXIE);
 #endif
-
-#endif
-#if defined(__MSP430_HAS_EUSCI_B0__)
+#elif defined(__MSP430_HAS_EUSCI_B0__)
     P1SEL1 |= BIT6 + BIT7;                  // Pin init
 
     //Disable the USCI module and clears the other bits of control register
@@ -258,12 +244,10 @@ void twi_setAddress(uint8_t address)
 {
 #if defined(__MSP430_HAS_USI__)
 	twi_my_addr = address << 1;
-#endif
-#if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
+#elif defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
 	/* UCGCEN = respond to general Call */
 	UCBxI2COA = (address | UCGCEN);
-#endif
-#if defined(__MSP430_HAS_EUSCI_B0__)
+#elif defined(__MSP430_HAS_EUSCI_B0__)
 	/* UCGCEN = respond to general Call */
 	UCB0I2COA0 = (address | UCOAEN | UCGCEN);
 #endif
@@ -287,8 +271,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
 	USICTL1 &= ~USISTTIE;
 	/* I2C master mode */
 	USICTL0 |= USIMST;
-#endif
-#if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
+#elif defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
     UCBxCTL1 = UCSWRST;                      // Enable SW reset
     UCBxCTL1 |= (UCSSEL_2);                  // I2C Master, synchronous mode
     UCBxCTL0 |= (UCMST | UCMODE_3 | UCSYNC); // I2C Master, synchronous mode
@@ -301,8 +284,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
 #else
     UCBxIE |= (UCALIE|UCNACKIE|UCSTPIE|UCRXIE|UCTXIE);  // Enable I2C interrupts
 #endif
-#endif
-#if defined(__MSP430_HAS_EUSCI_B0__)
+#elif defined(__MSP430_HAS_EUSCI_B0__)
     UCB0CTLW0 = UCSWRST;                      // Enable SW reset
     UCB0CTLW0 |= (UCMST | UCMODE_3 | UCSYNC | UCSSEL__SMCLK);   // I2C Master, synchronous mode
     UCB0CTLW0 &= ~(UCTR);                     // Configure in receive mode
@@ -333,8 +315,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
 	twi_state = TWI_SND_START;
 	// this will trigger an interrupt kicking off the state machine in the isr
 	USICTL1 |= USIIFG;
-#endif
-#if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
+#elif defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
     twi_state =  TWI_MRX;                     // Master receive mode
     UCBxCTL1 |= UCTXSTT;                      // I2C start condition
 
@@ -342,8 +323,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
         while(UCBxCTL1 & UCTXSTT);            // Wait for start bit to be sent
         UCBxCTL1 |= UCTXSTP;                  // Send I2C stop condition after recv
     }
-#endif
-#if defined(__MSP430_HAS_EUSCI_B0__)
+#elif defined(__MSP430_HAS_EUSCI_B0__)
     twi_state =  TWI_MRX;                     // Master receive mode
     while (UCB0CTLW0 & UCTXSTP);              // Ensure stop condition got sent
     UCB0CTLW0 |= UCTXSTT;                     // I2C start condition
@@ -393,8 +373,7 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
 	USICTL1 &= ~USISTTIE;
 	/* I2C master mode */
 	USICTL0 |= USIMST;
-#endif
-#if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
+#elif defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
     UCBxCTL1 = UCSWRST;                      // Enable SW reset
     UCBxCTL1 |= UCSSEL_2;                    // SMCLK
     UCBxCTL0 |= (UCMST | UCMODE_3 | UCSYNC); // I2C Master, synchronous mode
@@ -407,8 +386,7 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
 #else
     UCBxIE |= (UCALIE|UCNACKIE|UCSTPIE|UCTXIE);  // Enable I2C interrupts
 #endif
-#endif
-#if defined(__MSP430_HAS_EUSCI_B0__)
+#elif defined(__MSP430_HAS_EUSCI_B0__)
     UCB0CTLW0 = UCSWRST;                      // Enable SW reset
     UCB0CTLW0 |= (UCMST | UCMODE_3 | UCSSEL__SMCLK | UCSYNC);   // I2C Master, synchronous mode
     UCB0CTLW0 |= UCTR;                        // Configure in transmit mode
@@ -442,12 +420,10 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
 	twi_state = TWI_SND_START;
 	/* This will trigger an interrupt kicking off the state machine in the isr */
 	USICTL1 |= USIIFG;
-#endif
-#if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
+#elif defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
     twi_state =  TWI_MTX;                     // Master Transmit mode
     UCBxCTL1 |= UCTXSTT;                      // I2C start condition
-#endif
-#if defined(__MSP430_HAS_EUSCI_B0__)
+#elif defined(__MSP430_HAS_EUSCI_B0__)
     twi_state =  TWI_MTX;                     // Master Transmit mode
     while (UCB0CTLW0 & UCTXSTP);           // Ensure stop condition got sent
     UCB0CTLW0 |= UCTXSTT;                  // I2C start condition
@@ -652,9 +628,7 @@ mtre:
 	USICTL1 &= ~USIIFG;
 
 }
-#endif /* __MSP430_HAS_USI__ */
-
-#if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
+#elif defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
 void i2c_txrx_isr(void)  // RX/TX Service
 {
 	/* USCI I2C mode. USCI_Bx receive interrupt flag. */
@@ -809,9 +783,7 @@ void i2c_state_isr(void)  // I2C Service
 		twi_state =  TWI_IDLE;
 	}
 }
-#endif
-
-#if defined(__MSP430_HAS_EUSCI_B0__)
+#elif defined(__MSP430_HAS_EUSCI_B0__)
 __attribute__((interrupt(USCI_B0_VECTOR)))
 void USCI_B0_ISR(void)
 {

--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -93,6 +93,8 @@ static uint8_t twi_my_addr;
 #define UCBxIE        UCB0IE
 #define UCBxIFG       UCB0IFG
 #define UCBxIV        UCB0IV
+#define UCBxI2COA     UCB0I2COA
+#define UCBxI2CSA     UCB0I2CSA
 #else
 #define UCBxCTLW0     UCB1CTLW0
 #define UCBxCTL0      UCB1CTL0
@@ -113,6 +115,8 @@ static uint8_t twi_my_addr;
 #define UCBxIE        UCB1IE
 #define UCBxIFG       UCB1IFG
 #define UCBxIV        UCB1IV
+#define UCBxI2COA     UCB1I2COA
+#define UCBxI2CSA     UCB1I2CSA
 #endif
 #endif
 
@@ -246,7 +250,7 @@ void twi_setAddress(uint8_t address)
 #endif
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
 	/* UCGCEN = respond to general Call */
-	UCB0I2COA = (address | UCGCEN);
+	UCBxI2COA = (address | UCGCEN);
 #endif
 #if defined(__MSP430_HAS_EUSCI_B0__)
 	/* UCGCEN = respond to general Call */
@@ -278,7 +282,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
     UCBxCTL1 |= (UCSSEL_2);                  // I2C Master, synchronous mode
     UCBxCTL0 |= (UCMST | UCMODE_3 | UCSYNC); // I2C Master, synchronous mode
     UCBxCTL1 &= ~(UCTR);                     // Configure in receive mode
-    UCB0I2CSA = address;                     // Set Slave Address
+    UCBxI2CSA = address;                     // Set Slave Address
     UCBxCTL1 &= ~UCSWRST;                    // Clear SW reset, resume operation
 #if defined(__MSP430_HAS_USCI__)
     UCB0I2CIE |= (UCALIE|UCNACKIE|UCSTPIE);  // Enable I2C interrupts
@@ -384,7 +388,7 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
     UCBxCTL1 |= UCSSEL_2;                    // SMCLK
     UCBxCTL0 |= (UCMST | UCMODE_3 | UCSYNC); // I2C Master, synchronous mode
     UCBxCTL1 |= UCTR;                        // Configure in transmit mode
-    UCB0I2CSA = address;                     // Set Slave Address
+    UCBxI2CSA = address;                     // Set Slave Address
     UCBxCTL1 &= ~UCSWRST;                    // Clear SW reset, resume operation
 #if defined(__MSP430_HAS_USCI__)
     UCB0I2CIE |= (UCALIE|UCNACKIE|UCSTPIE);  // Enable I2C interrupts
@@ -642,11 +646,12 @@ mtre:
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
 void i2c_txrx_isr(void)  // RX/TX Service
 {
-	/* USCI I2C mode. USCI_Bx receive interrupt flag.
-	 * UCBxRXIFG is set when UCBxRXBUF has received a complete character. */
+	/* USCI I2C mode. USCI_Bx receive interrupt flag. */
 #if defined(__MSP430_HAS_USCI__)
+	/* UCB0RXIFG is set when UCBxRXBUF has received a complete character. */
 	if (UC0IFG & UCB0RXIFG){
 #else
+	/* UCRXIFG is set when UCBxRXBUF has received a complete character. */
 	if (UCBxIFG & UCRXIFG){
 #endif
 		/* Master receive mode. */
@@ -673,11 +678,12 @@ void i2c_txrx_isr(void)  // RX/TX Service
 			}
 		}
 	}
-	/* USCI I2C mode. USCI_Bx transmit interrupt flag.
-	 * UCB0TXIFG is set when UCBxTXBUF is empty.*/
+	/* USCI I2C mode. USCI_Bx transmit interrupt flag. */
 #if defined(__MSP430_HAS_USCI__)
+	/* UCB0TXIFG is set when UCBxTXBUF is empty.*/
 	if (UC0IFG & UCB0TXIFG){
 #else
+	/* UCTXIFG is set when UCBxTXBUF is empty.*/
 	if (UCBxIFG & UCTXIFG){
 #endif
 		/* Master transmit mode */

--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -30,11 +30,11 @@
 #include <stdlib.h>
 #include "Energia.h" // for digitalWrite
  
-#ifndef cbi
+#if !defined(cbi)
 #define cbi(sfr, bit) (_SFR_BYTE(sfr) &= ~_BV(bit))
 #endif
 
-#ifndef sbi
+#if !defined(sbi)
 #define sbi(sfr, bit) (_SFR_BYTE(sfr) |= _BV(bit))
 #endif
 
@@ -65,7 +65,7 @@ static volatile uint8_t twi_rxBufferIndex;
 
 static volatile uint8_t twi_error;
 
-#ifdef __MSP430_HAS_USI__
+#if defined(__MSP430_HAS_USI__)
 static uint8_t twi_slarw;
 static uint8_t twi_my_addr;
 
@@ -73,7 +73,7 @@ static uint8_t twi_my_addr;
 
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) \
  || defined(__MSP430_HAS_USCI_B1__)
-#ifndef USE_USCI_B1
+#if !defined(USE_USCI_B1)
 #define UCBxCTLW0     UCB0CTLW0
 #define UCBxCTL0      UCB0CTL0
 #define UCBxCTL1      UCB0CTL1
@@ -118,10 +118,10 @@ static uint8_t twi_my_addr;
 #endif
 #endif
 
-#ifdef __MSP430_HAS_USCI__
+#if defined(__MSP430_HAS_USCI__)
 #endif
 
-#ifdef __MSP430_HAS_EUSCI_B0__
+#if defined(__MSP430_HAS_EUSCI_B0__)
 #endif
 
 /*
@@ -137,7 +137,7 @@ void twi_init(void)
 	twi_sendStop = true;		// default value
 	twi_inRepStart = false;
 
-#ifdef __MSP430_HAS_USI__
+#if defined(__MSP430_HAS_USI__)
 
 	/* 100 KHz for all */
 #if (F_CPU >= 16000000L) || (F_CPU >= 12000000L)
@@ -202,7 +202,7 @@ void twi_init(void)
 #endif
 
 #endif
-#ifdef __MSP430_HAS_EUSCI_B0__
+#if defined(__MSP430_HAS_EUSCI_B0__)
 
     P1SEL1 |= BIT6 + BIT7;                  // Pin init
 
@@ -244,14 +244,14 @@ void twi_init(void)
  */
 void twi_setAddress(uint8_t address)
 {
-#ifdef __MSP430_HAS_USI__
+#if defined(__MSP430_HAS_USI__)
 	twi_my_addr = address << 1;
 #endif
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
 	/* UCGCEN = respond to general Call */
 	UCB0I2COA = (address | UCGCEN);
 #endif
-#ifdef __MSP430_HAS_EUSCI_B0__
+#if defined(__MSP430_HAS_EUSCI_B0__)
 	/* UCGCEN = respond to general Call */
 	UCB0I2COA0 = (address | UCOAEN | UCGCEN);
 #endif
@@ -270,7 +270,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
 {
 	uint8_t i;
 
-#ifdef __MSP430_HAS_USI__
+#if defined(__MSP430_HAS_USI__)
 	/* Disable START condition interrupt */
 	USICTL1 &= ~USISTTIE;
 	/* I2C master mode */
@@ -283,14 +283,14 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
     UCB0CTL1 &= ~(UCTR);                     // Configure in receive mode
     UCB0I2CSA = address;                     // Set Slave Address
     UCB0CTL1 &= ~UCSWRST;                    // Clear SW reset, resume operation
-#ifdef __MSP430_HAS_USCI__
+#if defined(__MSP430_HAS_USCI__)
     UCB0I2CIE |= (UCALIE|UCNACKIE|UCSTPIE);  // Enable I2C interrupts
     UC0IE |= (UCB0RXIE | UCB0TXIE);          // Enable I2C interrupts
 #else
     UCB0IE |= (UCALIE|UCNACKIE|UCSTPIE|UCRXIE|UCTXIE);  // Enable I2C interrupts
 #endif
 #endif
-#ifdef __MSP430_HAS_EUSCI_B0__
+#if defined(__MSP430_HAS_EUSCI_B0__)
     UCB0CTLW0 = UCSWRST;                      // Enable SW reset
     UCB0CTLW0 |= (UCMST | UCMODE_3 | UCSYNC | UCSSEL__SMCLK);   // I2C Master, synchronous mode
     UCB0CTLW0 &= ~(UCTR);                     // Configure in receive mode
@@ -312,7 +312,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
 	// received, causing that NACK to be sent in response to receiving the last
 	// expected byte of data.
 
-#ifdef __MSP430_HAS_USI__
+#if defined(__MSP430_HAS_USI__)
 	/* build sla+w, slave device address + w bit */
 	twi_slarw = 1;
 	twi_slarw |= address << 1;
@@ -331,7 +331,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
         UCB0CTL1 |= UCTXSTP;                  // Send I2C stop condition after recv
     }
 #endif
-#ifdef __MSP430_HAS_EUSCI_B0__
+#if defined(__MSP430_HAS_EUSCI_B0__)
     twi_state =  TWI_MRX;                     // Master receive mode
     while (UCB0CTLW0 & UCTXSTP);              // Ensure stop condition got sent
     UCB0CTLW0 |= UCTXSTT;                     // I2C start condition
@@ -376,7 +376,7 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
 	twi_error = TWI_ERRROR_NO_ERROR;
 	twi_sendStop = sendStop;
 
-#ifdef __MSP430_HAS_USI__
+#if defined(__MSP430_HAS_USI__)
 	/* Disable START condition interrupt */
 	USICTL1 &= ~USISTTIE;
 	/* I2C master mode */
@@ -389,14 +389,14 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
     UCB0CTL1 |= UCTR;                        // Configure in transmit mode
     UCB0I2CSA = address;                     // Set Slave Address
     UCB0CTL1 &= ~UCSWRST;                    // Clear SW reset, resume operation
-#ifdef __MSP430_HAS_USCI__
+#if defined(__MSP430_HAS_USCI__)
     UCB0I2CIE |= (UCALIE|UCNACKIE|UCSTPIE);  // Enable I2C interrupts
     UC0IE |= UCB0TXIE;                     // Enable I2C interrupts
 #else
     UCB0IE |= (UCALIE|UCNACKIE|UCSTPIE|UCTXIE);  // Enable I2C interrupts
 #endif
 #endif
-#ifdef __MSP430_HAS_EUSCI_B0__
+#if defined(__MSP430_HAS_EUSCI_B0__)
     UCB0CTLW0 = UCSWRST;                      // Enable SW reset
     UCB0CTLW0 |= (UCMST | UCMODE_3 | UCSSEL__SMCLK | UCSYNC);   // I2C Master, synchronous mode
     UCB0CTLW0 |= UCTR;                        // Configure in transmit mode
@@ -422,7 +422,7 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
 		twi_masterBuffer[i] = data[i];
 	}
 
-#ifdef __MSP430_HAS_USI__
+#if defined(__MSP430_HAS_USI__)
 	/* build sla+w, slave device address + w bit */
 	twi_slarw = 0;
 	twi_slarw |= address << 1;
@@ -435,7 +435,7 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
     twi_state =  TWI_MTX;                     // Master Transmit mode
     UCB0CTL1 |= UCTXSTT;                      // I2C start condition
 #endif
-#ifdef __MSP430_HAS_EUSCI_B0__
+#if defined(__MSP430_HAS_EUSCI_B0__)
     twi_state =  TWI_MTX;                     // Master Transmit mode
     while (UCB0CTLW0 & UCTXSTP);           // Ensure stop condition got sent
     UCB0CTLW0 |= UCTXSTT;                  // I2C start condition
@@ -514,7 +514,7 @@ void twi_attachSlaveTxEvent( void (*function)(void) )
 
 void send_start()
 {
-#ifdef __MSP430_HAS_USI__
+#if defined(__MSP430_HAS_USI__)
 	USISRL = 0x00;
 	USICTL0 |= USIGE+USIOE;
 	USICTL0 &= ~USIGE;
@@ -523,7 +523,7 @@ void send_start()
 #endif
 }
 
-#ifdef __MSP430_HAS_USI__
+#if defined(__MSP430_HAS_USI__)
 __attribute__((interrupt(USI_VECTOR)))
 void USI_ISR(void)
 {
@@ -647,7 +647,7 @@ void i2c_txrx_isr(void)  // RX/TX Service
 {
 	/* USCI I2C mode. USCI_B0 receive interrupt flag.
 	 * UCB0RXIFG is set when UCB0RXBUF has received a complete character. */
-#ifdef __MSP430_HAS_USCI__
+#if defined(__MSP430_HAS_USCI__)
 	if (UC0IFG & UCB0RXIFG){
 #else
 	if (UCB0IFG & UCRXIFG){
@@ -678,7 +678,7 @@ void i2c_txrx_isr(void)  // RX/TX Service
 	}
 	/* USCI I2C mode. USCI_B0 transmit interrupt flag.
 	 * UCB0TXIFG is set when UCB0TXBUF is empty.*/
-#ifdef __MSP430_HAS_USCI__
+#if defined(__MSP430_HAS_USCI__)
 	if (UC0IFG & UCB0TXIFG){
 #else
 	if (UCB0IFG & UCTXIFG){
@@ -721,7 +721,7 @@ void i2c_txrx_isr(void)  // RX/TX Service
 void i2c_state_isr(void)  // I2C Service
 {
 	/* Arbitration lost interrupt flag */
-#ifdef __MSP430_HAS_USCI__
+#if defined(__MSP430_HAS_USCI__)
 	if (UCB0STAT & UCALIFG) {
 		UCB0STAT &= ~UCALIFG;
 #else
@@ -732,7 +732,7 @@ void i2c_state_isr(void)  // I2C Service
 	}
 	/* Not-acknowledge received interrupt flag. 
 	 * UCNACKIFG is automatically cleared when a START condition is received.*/
-#ifdef __MSP430_HAS_USCI__
+#if defined(__MSP430_HAS_USCI__)
 	if (UCB0STAT & UCNACKIFG) {
 		UCB0STAT &= ~UCNACKIFG;
 #else
@@ -748,7 +748,7 @@ void i2c_state_isr(void)  // I2C Service
 	}
 	/* Start condition interrupt flag.
 	 * UCSTTIFG is automatically cleared if a STOP condition is received. */
-#ifdef __MSP430_HAS_USCI__
+#if defined(__MSP430_HAS_USCI__)
 	 if (UCB0STAT & UCSTTIFG) {
 		UCB0STAT &= ~UCSTTIFG;
 #else
@@ -781,7 +781,7 @@ void i2c_state_isr(void)  // I2C Service
 	}
 	/* Stop condition interrupt flag.
 	 * UCSTPIFG is automatically cleared when a START condition is received. */
-#ifdef __MSP430_HAS_USCI__
+#if defined(__MSP430_HAS_USCI__)
 	if (UCB0STAT & UCSTPIFG) {
 		UCB0STAT &= ~UCSTPIFG;
 #else
@@ -797,7 +797,7 @@ void i2c_state_isr(void)  // I2C Service
 }
 #endif
 
-#ifdef __MSP430_HAS_EUSCI_B0__
+#if defined(__MSP430_HAS_EUSCI_B0__)
 __attribute__((interrupt(USCI_B0_VECTOR)))
 void USCI_B0_ISR(void)
 {

--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -630,7 +630,6 @@ mtre:
 
 	/* Clear counter interrupt */
 	USICTL1 &= ~USIIFG;
-
 }
 #elif defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
 void i2c_txrx_isr(void)  // RX/TX Service
@@ -788,8 +787,7 @@ void i2c_state_isr(void)  // I2C Service
 	}
 }
 
-#if defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
-#ifndef USE_USCI_B1
+#if defined(__MSP430_HAS_USCI_B0__)
 __attribute__((interrupt(USCI_B0_VECTOR)))
 void USCIB0_ISR(void)
 {
@@ -805,7 +803,9 @@ void USCIB0_ISR(void)
 	if (still_asleep != stay_asleep)
 		__bic_SR_register_on_exit(LPM4_bits);
 }
-#else
+#endif
+
+#if defined(__MSP430_HAS_USCI_B1__)
 __attribute__((interrupt(USCI_B1_VECTOR)))
 void USCIB1_ISR(void)
 {
@@ -821,7 +821,6 @@ void USCIB1_ISR(void)
 	if (still_asleep != stay_asleep)
 		__bic_SR_register_on_exit(LPM4_bits);
 }
-#endif
 #endif
 
 #elif defined(__MSP430_HAS_EUSCI_B0__)

--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -77,25 +77,15 @@ static uint8_t twi_my_addr;
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_B0__) \
  || defined(__MSP430_HAS_USCI_B1__)
 #if !defined(USE_USCI_B1)
-#define UCBxCTLW0     UCB0CTLW0
 #define UCBxCTL0      UCB0CTL0
 #define UCBxCTL1      UCB0CTL1
-#define UCBxBRW       UCB0BRW
 #define UCBxBR0       UCB0BR0
 #define UCBxBR1       UCB0BR1
-#define UCBxMCTL      UCB0MCTL
-#define UCBxMCTLW     UCB0MCTLW
 #define UCBxSTAT      UCB0STAT
 #define UCBxRXBUF     UCB0RXBUF
 #define UCBxTXBUF     UCB0TXBUF
-#define UCBxABCTL     UCB0ABCTL
-#define UCBxIRCTL     UCB0IRCTL
-#define UCBxIRTCTL    UCB0IRTCTL
-#define UCBxIRRCTL    UCB0IRRCTL
-#define UCBxICTL      UCB0ICTL
 #define UCBxIE        UCB0IE
 #define UCBxIFG       UCB0IFG
-#define UCBxIV        UCB0IV
 #define UCBxI2COA     UCB0I2COA
 #define UCBxI2CSA     UCB0I2CSA
 #define TWISDAx       TWISDA
@@ -103,25 +93,15 @@ static uint8_t twi_my_addr;
 #define TWISDA_SET_MODEx TWISDA_SET_MODE
 #define TWISCL_SET_MODEx TWISCL_SET_MODE
 #else
-#define UCBxCTLW0     UCB1CTLW0
 #define UCBxCTL0      UCB1CTL0
 #define UCBxCTL1      UCB1CTL1
-#define UCBxBRW       UCB1BRW
 #define UCBxBR0       UCB1BR0
 #define UCBxBR1       UCB1BR1
-#define UCBxMCTL      UCB1MCTL
-#define UCBxMCTLW     UCB1MCTLW
 #define UCBxSTAT      UCB1STAT
 #define UCBxRXBUF     UCB1RXBUF
 #define UCBxTXBUF     UCB1TXBUF
-#define UCBxABCTL     UCB1ABCTL
-#define UCBxIRCTL     UCB1IRCTL
-#define UCBxIRTCTL    UCB1IRTCTL
-#define UCBxIRRCTL    UCB1IRRCTL
-#define UCBxICTL      UCB1ICTL
 #define UCBxIE        UCB1IE
 #define UCBxIFG       UCB1IFG
-#define UCBxIV        UCB1IV
 #define UCBxI2COA     UCB1I2COA
 #define UCBxI2CSA     UCB1I2CSA
 #define TWISDAx       TWISDA1

--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -29,6 +29,8 @@
 #include <math.h>
 #include <stdlib.h>
 #include "Energia.h" // for digitalWrite
+
+#define USE_USCI_B1
  
 #if !defined(cbi)
 #define cbi(sfr, bit) (_SFR_BYTE(sfr) &= ~_BV(bit))
@@ -176,10 +178,6 @@ void twi_init(void)
      * from stripping the USCI interupt vectors.*/ 
     usci_isr_install();
 
-    /* Set pins to I2C mode */
-    pinMode_int(TWISDAx, TWISDA_SET_MODEx);
-    pinMode_int(TWISCLx, TWISCL_SET_MODEx);
-
     //Disable the USCI module and clears the other bits of control register
     UCBxCTL1 = UCSWRST;
 
@@ -199,6 +197,11 @@ void twi_init(void)
     UCBxBR0 = (unsigned char)((F_CPU / TWI_FREQ) & 0xFF);
     UCBxBR1 = (unsigned char)((F_CPU / TWI_FREQ) >> 8);
 
+    /* Set pins to I2C mode */
+    pinMode_int(TWISDAx, TWISDA_SET_MODEx);
+    pinMode_int(TWISCLx, TWISCL_SET_MODEx);
+
+    /* Enable the USCI module */
     UCBxCTL1 &= ~(UCSWRST);
 
 #if defined(__MSP430_HAS_USCI__)

--- a/hardware/msp430/cores/msp430/twi.h
+++ b/hardware/msp430/cores/msp430/twi.h
@@ -89,7 +89,7 @@
 
 
 
-void twi_init(void);
+void twi_init(uint8_t module);
 void twi_setAddress(uint8_t);
 uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t);
 uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t);

--- a/hardware/msp430/cores/msp430/usci_isr_handler.c
+++ b/hardware/msp430/cores/msp430/usci_isr_handler.c
@@ -1,6 +1,6 @@
 #include "Energia.h"
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_A0__) || defined(__MSP430_HAS_USCI_A1__) \
- || defined(__MSP430_HAS_EUSCI_A0__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
+ || defined(__MSP430_HAS_EUSCI_A0__)
 #include "usci_isr_handler.h"
 /* This dummy function ensures that, when called from any module that 
  * is interested in having the USCIAB0TX_VECTOR and USCIAB0TX_VECTOR
@@ -60,44 +60,6 @@ void USCIA1_ISR(void)
 }
 #endif
 
-#define USE_USCI_B1
-
-#if defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
-#ifndef USE_USCI_B1
-__attribute__((interrupt(USCI_B0_VECTOR)))
-void USCIB0_ISR(void)
-{
-	still_asleep = stay_asleep;
-
-	/* USCI_B0 I2C state change interrupt. */
-	if ((UCB0CTL0 & UCMODE_3) == UCMODE_3 && (UCB0IFG & (UCALIFG | UCNACKIFG | UCSTTIFG | UCSTPIFG)) != 0)
-		i2c_state_isr(); 
-	/* USCI_B0 I2C TX RX interrupt. */
-	if ((UCB0CTL0 & UCMODE_3) == UCMODE_3 && (UCB0IFG & (UCTXIFG | UCRXIFG)) != 0)
-		i2c_txrx_isr();
-
-	if (still_asleep != stay_asleep)
-		__bic_SR_register_on_exit(LPM4_bits);
-}
-#else
-__attribute__((interrupt(USCI_B1_VECTOR)))
-void USCIB1_ISR(void)
-{
-	still_asleep = stay_asleep;
-
-	/* USCI_B1 I2C state change interrupt. */
-	if ((UCB1CTL0 & UCMODE_3) == UCMODE_3 && (UCB1IFG & (UCALIFG | UCNACKIFG | UCSTTIFG | UCSTPIFG)) != 0)
-		i2c_state_isr(); 
-	/* USCI_B1 I2C TX RX interrupt. */
-	if ((UCB1CTL0 & UCMODE_3) == UCMODE_3 && (UCB1IFG & (UCTXIFG | UCRXIFG)) != 0)
-		i2c_txrx_isr();
-
-	if (still_asleep != stay_asleep)
-		__bic_SR_register_on_exit(LPM4_bits);
-}
-#endif
-#endif
-
 #endif //defined(__MSP430_HAS_USCI_A0__) || defined(__MSP430_HAS_USCI_A1__) || defined(__MSP430_HAS_EUSCI_A0__)
 
 #ifdef __MSP430_HAS_USCI__
@@ -139,10 +101,11 @@ void USCIAB0RX_ISR(void)
 
 	/* USCI_B0 I2C state change interrupt. */
 	if ((UCB0STAT & (UCALIFG | UCNACKIFG | UCSTTIFG | UCSTPIFG)) != 0)
-		i2c_state_isr(); 
+		i2c_state_isr();
 
 	if (still_asleep != stay_asleep)
 		__bic_SR_register_on_exit(LPM4_bits);
 }
 #endif // __MSP430_HAS_USCI__
 #endif // entire file
+

--- a/hardware/msp430/cores/msp430/usci_isr_handler.c
+++ b/hardware/msp430/cores/msp430/usci_isr_handler.c
@@ -60,6 +60,8 @@ void USCIA1_ISR(void)
 }
 #endif
 
+#define USE_USCI_B1
+
 #if defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
 #ifndef USE_USCI_B1
 __attribute__((interrupt(USCI_B0_VECTOR)))

--- a/hardware/msp430/cores/msp430/usci_isr_handler.c
+++ b/hardware/msp430/cores/msp430/usci_isr_handler.c
@@ -1,6 +1,6 @@
 #include "Energia.h"
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_A0__) || defined(__MSP430_HAS_USCI_A1__) \
- || defined(__MSP430_HAS_EUSCI_A0__)|| defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__) 
+ || defined(__MSP430_HAS_EUSCI_A0__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
 #include "usci_isr_handler.h"
 /* This dummy function ensures that, when called from any module that 
  * is interested in having the USCIAB0TX_VECTOR and USCIAB0TX_VECTOR

--- a/hardware/msp430/cores/msp430/usci_isr_handler.h
+++ b/hardware/msp430/cores/msp430/usci_isr_handler.h
@@ -2,7 +2,7 @@
 #define usci_isr_handler_h
 
 #if defined(__MSP430_HAS_USCI__) || defined(__MSP430_HAS_USCI_A0__) || defined(__MSP430_HAS_USCI_A1__) \
- || defined(__MSP430_HAS_EUSCI_A0__)|| defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__) 
+ || defined(__MSP430_HAS_EUSCI_A0__) || defined(__MSP430_HAS_USCI_B0__) || defined(__MSP430_HAS_USCI_B1__)
 
 typedef void CHardwareSerial;
 #ifdef __cplusplus

--- a/hardware/msp430/variants/launchpad_f5529/pins_energia.h
+++ b/hardware/msp430/variants/launchpad_f5529/pins_energia.h
@@ -43,12 +43,19 @@ static const uint8_t MOSI    = 15;  /* P3.0 */
 static const uint8_t MISO    = 14;  /* P3.1 */
 static const uint8_t TWISDA  = 15;  /* P3.0 */
 static const uint8_t TWISCL  = 14;  /* P3.1 */
+static const uint8_t TWISDA1  = 10; /* P4.1 */
+static const uint8_t TWISCL1  = 9;  /* P4.2 */
 static const uint8_t DEBUG_UARTRXD = 45;  /* Receive  Data (RXD) at P4.5 */
 static const uint8_t DEBUG_UARTTXD = 46;  /* Transmit Data (TXD) at P4.4 */
 static const uint8_t AUX_UARTRXD = 3;  /* Receive  Data (RXD) at P4.5 */
 static const uint8_t AUX_UARTTXD = 4;  /* Transmit Data (TXD) at P4.4 */
 #define TWISDA_SET_MODE (PORT_SELECTION0)
 #define TWISCL_SET_MODE (PORT_SELECTION0)
+#if defined(__MSP430_HAS_USCI_B1__)
+/* For USCI_B1 */
+#define TWISDA_SET_MODE1 (PORT_SELECTION0 | (PM_UCB1SDA << 8) | INPUT)
+#define TWISCL_SET_MODE1 (PORT_SELECTION0 | (PM_UCB1SCL << 8) | INPUT)
+#endif
 #define DEBUG_UARTRXD_SET_MODE (PORT_SELECTION0 | (PM_UCA1RXD << 8) | INPUT)
 #define DEBUG_UARTTXD_SET_MODE (PORT_SELECTION0 | (PM_UCA1TXD << 8) | OUTPUT)
 #define AUX_UARTRXD_SET_MODE (PORT_SELECTION0 | INPUT)


### PR DESCRIPTION
The Launchpad F5529 supports both USCI_B0 and USCI_B1 for i2c communcation.

This pull request adds support for choosing which module to use, by adding a "Wire.setModule(1)" before doing "Wire.begin()" in a sketch.

So this pull request allows one to choose which module to use, but it does not allow one to use both modules.

This is an attempt at making a simpler, i.e. less changes, pull request than pull request #398.
I think as a first step, it would be nice to at least choose which module to use.

Comments are appreciated.
Is there for example a better way to switch between registeres for USCI_B0 and USCI_B1 than using pointers ?

Note that this pull request also contains some i2c cleanup, which I've made separate pull requests for.
So I think the other pull requests should be merged first, and then I could rebase this pull request.

But I wanted to have the code as nice as possible in this pull request, so you can comment on what you like and dislike.

Regards
Alf Hogemark