### PR TITLE
Update wiring.c

### DIFF
--- a/hardware/msp430/cores/msp430/wiring.c
+++ b/hardware/msp430/cores/msp430/wiring.c
@@ -163,7 +163,7 @@ void initClocks(void)
 //    CSCTL0 = 0;                    // Disable Access to CS Registers
 #endif // __MSP430_HAS_CS__
 
-#if defined(__MSP430_HAS_UCS__)
+#if defined(__MSP430_HAS_UCS__) || defined(__MSP430_HAS_UCS_RF__)
      PMMCTL0_H = PMMPW_H;             // open PMM
 	 SVSMLCTL &= ~SVSMLRRL_7;         // reset
 	 PMMCTL0_L = PMMCOREV_0;          //


### PR DESCRIPTION
Allows CC430 to work on Energia (variant is needed)

Tested on Ez430 chronos and Olimex cc430 boards