### PR TITLE
Improve MSP432 name consistency with other boards

### DIFF
--- a/hardware/msp432/boards.txt
+++ b/hardware/msp432/boards.txt
@@ -1,5 +1,5 @@
 ##############################################################
-MSP-EXP432P401R.name=MSP-EXP432P401R (48MHz)
+MSP-EXP432P401R.name=LaunchPad w/ msp432 EMT (48MHz)
 MSP-EXP432P401R.upload.maximum_size=262144
 MSP-EXP432P401R.build.mcu=cortex-m4f
 MSP-EXP432P401R.build.f_cpu=48000000L


### PR DESCRIPTION
Improve name consistency with other boards
`MSP-EXP432P401R.name=LaunchPad w/ msp432 EMT (48MHz)`