### PR TITLE
Initial version for FR6989 and FR4133 - added new files to support La…

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -228,7 +228,7 @@
 
 
   <property name="arm.tools.mac.local" value="arm_tools_mac.zip"/>
-  <property name="msp430.tools.mac.local" value="msp430_tools_mac.zip"/>
+  <property name="msp430.tools.mac.local" value="msp430_tools_mac_05_2015.zip"/>
 
   <condition property="exists.tools.mac">
   <and>
@@ -254,7 +254,7 @@
     if="dep.arm.default.ok"
     unless="exists.tools.mac">
     <property name="arm.tools.mac.remote" value="http://energia.nu/files/arm_tools_mac.zip"/>
-	<property name="msp430.tools.mac.remote" value="http://energia.nu/files/msp430_tools_mac.zip"/>
+	<property name="msp430.tools.mac.remote" value="http://energia.nu/files/msp430_tools_mac_05_2015.zip"/>
     <!-- Get tools tools -->
 	<get src="${arm.tools.mac.remote}" dest="macosx/${arm.tools.mac.local}"/>
 	<get src="${msp430.tools.mac.remote}" dest="macosx/${msp430.tools.mac.local}"/>
@@ -291,7 +291,7 @@
       <arg value="-n" />
       <arg value="-d" />
       <arg value="macosx/work/Energia.app/Contents/Resources/Java/hardware/tools" />
-      <arg value="macosx/msp430_tools_mac.zip" />
+      <arg value="macosx/msp430_tools_mac_05_2015.zip" />
     </exec>
 
     <!-- Unzip arm tools -->
@@ -432,7 +432,7 @@
 
   <!-- Linux 32 build -->
   <property name="arm.tools.linux.local" value="arm_tools_linux32.tar.bz2"/>
-  <property name="msp430.tools.linux.local" value="msp430_tools_linux32.tar.bz2"/>
+  <property name="msp430.tools.linux.local" value="msp430_tools_linux32_05_2015.tar.bz2"/>
 
   <condition property="exists.tools.linux">
   <and>
@@ -455,7 +455,7 @@
     if="dep.arm.default.ok"
     unless="exists.tools.linux">
     <property name="arm.tools.linux.remote" value="http://energia.nu/files/arm_tools_linux32.tar.bz2"/>
-	<property name="msp430.tools.linux.remote" value="http://energia.nu/files/msp430_tools_linux32.tar.bz2"/>
+	<property name="msp430.tools.linux.remote" value="http://energia.nu/files/msp430_tools_linux32_05_2015.tar.bz2"/>
     <!-- Get tools -->
 	<get src="${arm.tools.linux.remote}" dest="linux/${arm.tools.linux.local}"/>
 	<get src="${msp430.tools.linux.remote}" dest="linux/${msp430.tools.linux.local}"/>
@@ -466,7 +466,7 @@
     <!-- Unzip msp430 tools -->
     <exec executable="tar" dir="linux/work/hardware/tools">
       <arg value="-xjf"/>
-      <arg value="${user.dir}/linux/msp430_tools_linux32.tar.bz2"/>
+      <arg value="${user.dir}/linux/msp430_tools_linux32_05_2015.tar.bz2"/>
     </exec>
     <!-- Unzip lm4f tools -->
     <exec executable="tar" dir="linux/work/hardware/tools">
@@ -477,7 +477,7 @@
 
   <!-- Linux 64 build -->
   <property name="arm.tools.linux64.local" value="arm_tools_linux64.tar.bz2"/>
-  <property name="msp430.tools.linux64.local" value="msp430_tools_linux64.tar.bz2"/>
+  <property name="msp430.tools.linux64.local" value="msp430_tools_linux64_05_2015.tar.bz2"/>
 
   <condition property="exists.tools.linux64">
   <and>
@@ -491,7 +491,7 @@
     if="dep.arm.default.ok"
     unless="exists.tools.linux64">
     <property name="arm.tools.linux64.remote" value="http://energia.nu/files/arm_tools_linux64.tar.bz2"/>
-	<property name="msp430.tools.linux64.remote" value="http://energia.nu/files/msp430_tools_linux64.tar.bz2"/>
+	<property name="msp430.tools.linux64.remote" value="http://energia.nu/files/msp430_tools_linux64_05_2015.tar.bz2"/>
     <!-- Get tools -->
 	<get src="${arm.tools.linux64.remote}" dest="linux/${arm.tools.linux64.local}"/>
 	<get src="${msp430.tools.linux64.remote}" dest="linux/${msp430.tools.linux64.local}"/>
@@ -502,7 +502,7 @@
     <copy tofile="linux/work/lib/librxtxSerial.so" file="linux/dist/lib/librxtxSerial64.so" overwrite="true" />
     <exec executable="tar" dir="linux/work/hardware/tools">
       <arg value="-xjf"/>
-      <arg value="${user.dir}/linux/msp430_tools_linux64.tar.bz2"/>
+      <arg value="${user.dir}/linux/msp430_tools_linux64_05_2015.tar.bz2"/>
     </exec>
 
     <!-- Unzip lm4f tools -->
@@ -598,7 +598,7 @@
   </target>
   
   <property name="arm.tools.windows.local" value="arm_tools_windows.zip"/>
-  <property name="msp430.tools.windows.local" value="msp430_tools_windows.zip"/>
+  <property name="msp430.tools.windows.local" value="msp430_tools_windows_05_2015.zip"/>
 
   <condition property="exists.tools.windows">
   <and>
@@ -622,7 +622,7 @@
     if="dep.arm.default.ok"
     unless="exists.tools.windows">
     <property name="arm.tools.windows.remote" value="http://energia.nu/files/arm_tools_windows.zip"/>
-	<property name="msp430.tools.windows.remote" value="http://energia.nu/files/msp430_tools_windows.zip"/>
+	<property name="msp430.tools.windows.remote" value="http://energia.nu/files/msp430_tools_windows_05_2015.zip"/>
     <!-- Get tools tools -->
 	<get src="${arm.tools.windows.remote}" dest="windows/${arm.tools.windows.local}"/>
 	<get src="${msp430.tools.windows.remote}" dest="windows/${msp430.tools.windows.local}"/>
@@ -655,7 +655,7 @@
 
 
     <!-- Unzip tools -->
-    <unzip dest="windows/work/hardware/tools" src="windows/msp430_tools_windows.zip" overwrite="false"/>
+    <unzip dest="windows/work/hardware/tools" src="windows/msp430_tools_windows_05_2015.zip" overwrite="false"/>
     <unzip dest="windows/work/hardware/tools" src="windows/arm_tools_windows.zip" overwrite="false"/>
 
     <antcall target="assemble">

--- a/hardware/msp430/boards.txt
+++ b/hardware/msp430/boards.txt
@@ -81,3 +81,25 @@ lpmsp430fr5969.build.variant=launchpad_fr5969
 lpmsp430fr5969.upload.maximum_ram_size=1024
 
 ##############################################################
+lpmsp430fr4133.name=LaunchPad w/ msp430fr4133
+lpmsp430fr4133.upload.protocol=tilib
+lpmsp430fr4133.upload.maximum_size=15360
+lpmsp430fr4133.build.mcu=msp430fr4133
+#lpmsp430fr4133.build.f_cpu=16000000L
+lpmsp430fr4133.build.f_cpu=8000000L
+lpmsp430fr4133.build.core=msp430
+lpmsp430fr4133.build.variant=launchpad_fr4133
+lpmsp430fr4133.upload.maximum_ram_size=1024
+
+##############################################################
+lpmsp430fr6989.name=LaunchPad w/ msp430fr6989
+lpmsp430fr6989.upload.protocol=tilib
+lpmsp430fr6989.upload.maximum_size=130048
+lpmsp430fr6989.build.mcu=msp430fr6989
+#lpmsp430fr6989.build.f_cpu=16000000L
+lpmsp430fr6989.build.f_cpu=8000000L
+lpmsp430fr6989.build.core=msp430
+lpmsp430fr6989.build.variant=launchpad_fr6989
+lpmsp430fr6989.upload.maximum_ram_size=1024
+
+##############################################################

--- a/hardware/msp430/cores/msp430/Energia.h
+++ b/hardware/msp430/cores/msp430/Energia.h
@@ -67,12 +67,21 @@ extern "C"{
 #define INTERNAL2V5 ((ADC12SREF_1 << 4) | REFON | REFMSTR | REFVSEL_2)
 #define EXTERNAL (ADC12SREF_2 << 4)
 #endif
+
 #if defined(__MSP430_HAS_ADC12_B__)
 #define DEFAULT ADC12VRSEL_0
 #define INTERNAL1V2 (ADC12VRSEL_1 | REFON | REFVSEL_0)
 #define INTERNAL2V0 (ADC12VRSEL_1 | REFON | REFVSEL_1)
 #define INTERNAL2V5 (ADC12VRSEL_1 | REFON | REFVSEL_2)
 #define EXTERNAL ADC12VRSEL_2
+#endif
+
+#if defined(__MSP430_HAS_ADC__)
+#define DEFAULT ADCSREF_0
+#define INTERNAL1V2 (ADCSREF_1 | REFON | REFVSEL_0)
+#define INTERNAL2V0 (ADCSREF_1 | REFON | REFVSEL_1)
+#define INTERNAL2V5 (ADCSREF_1 | REFON | REFVSEL_2)
+#define EXTERNAL ADCSREF_2
 #endif
 
 enum{
@@ -95,6 +104,18 @@ enum{
 #endif
 #ifdef __MSP430_HAS_PORT8_R__
   P8,
+#endif
+#ifdef __MSP430_HAS_PORT9_R__
+  P9,
+#endif
+#ifdef __MSP430_HAS_PORT10_R__
+  P10,
+#endif
+#ifdef __MSP430_HAS_PORT11_R__
+  P11,
+#endif
+#ifdef __MSP430_HAS_PORT12_R__
+  P12,
 #endif
 #ifdef __MSP430_HAS_PORTJ_R__
   PJ,

--- a/hardware/msp430/variants/launchpad_f5529/pins_energia.h
+++ b/hardware/msp430/variants/launchpad_f5529/pins_energia.h
@@ -129,7 +129,7 @@ static const uint8_t P3_0 = 15;
 static const uint8_t P7_4 = 17;
 static const uint8_t P2_2 = 18;
 static const uint8_t P2_0 = 19;
-/* PIN16 is GND */
+/* PIN20 is GND */
 
 /* PIN21 is 5.0v */
 /* PIN22 is GND */

--- a/hardware/msp430/variants/launchpad_fr5969/pins_energia.h
+++ b/hardware/msp430/variants/launchpad_fr5969/pins_energia.h
@@ -184,7 +184,7 @@ static const uint8_t GREEN_LED = 26;
 
 static const uint8_t PUSH1 = 27;
 static const uint8_t PUSH2 = 28;
-static const uint8_t TEMPSENSOR = 128 + 10; // depends on chip
+static const uint8_t TEMPSENSOR = 128 + 30; // depends on chip
 
 #ifdef ARDUINO_MAIN
 


### PR DESCRIPTION
This is the initial support package for the FR6989 and FR4133 Launchpads.
It contains all the basic support functions and updates for the files required by Energia.
For the support of this devices a newer Compiler tool chain needs to be used which is also integrated into the build scripts.