### PR TITLE
Issue 651

### DIFF
--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -195,9 +195,13 @@ void twi_init(void)
     pinMode_int(TWISDA, INPUT_PULLUP);
     if (digitalRead(TWISDA) == 0){ // toggle SCL if SDA is low at startup
         pinMode_int(TWISCL, INPUT_PULLUP);
-        pinMode(TWISCL, OUTPUT);
         digitalWrite(TWISCL, LOW);
+        pinMode(TWISCL, OUTPUT);
         pinMode_int(TWISCL, INPUT_PULLUP);
+    }
+    if ((TWISDA_SET_MODE & INPUT_PULLUP) == 0) {
+    	pinMode(TWISDA, INPUT);          // some device do not allow the pull up to be enabled
+    	pinMode(TWISCL, INPUT);
     }
     pinMode_int(TWISDA, TWISDA_SET_MODE);
     pinMode_int(TWISCL, TWISCL_SET_MODE);

--- a/hardware/msp430/cores/msp430/usci_isr_handler.c
+++ b/hardware/msp430/cores/msp430/usci_isr_handler.c
@@ -112,6 +112,7 @@ void USCIB1_ISR(void)
 __attribute__((interrupt(USCIAB0TX_VECTOR))) 
 void USCIAB0TX_ISR(void)
 {
+	uint16_t stay_active = false;
 	still_asleep = stay_asleep;
 
 	/* USCI_A0 UART interrupt? */
@@ -120,15 +121,16 @@ void USCIAB0TX_ISR(void)
 
 	/* USCI_B0 I2C TX RX interrupt. */
 	if ((UCB0CTL0 & UCMODE_3) == UCMODE_3 && (UC0IFG & (UCB0TXIFG | UCB0RXIFG)) != 0)
-		i2c_txrx_isr();
+		stay_active = i2c_txrx_isr();
 
-	if (still_asleep != stay_asleep)
+	if (still_asleep != stay_asleep || stay_active)
 		__bic_SR_register_on_exit(LPM4_bits);
 }
 
 __attribute__((interrupt(USCIAB0RX_VECTOR)))
 void USCIAB0RX_ISR(void)
 {
+	uint16_t stay_active = false;
 	still_asleep = stay_asleep;
 
 	/* USCI_A0 UART interrupt? */
@@ -137,9 +139,9 @@ void USCIAB0RX_ISR(void)
 
 	/* USCI_B0 I2C state change interrupt. */
 	if ((UCB0STAT & (UCALIFG | UCNACKIFG | UCSTTIFG | UCSTPIFG)) != 0)
-		i2c_state_isr(); 
+		stay_active = i2c_state_isr(); 
 
-	if (still_asleep != stay_asleep)
+	if (still_asleep != stay_asleep || stay_active)
 		__bic_SR_register_on_exit(LPM4_bits);
 }
 #endif // __MSP430_HAS_USCI__

--- a/hardware/msp430/cores/msp430/usci_isr_handler.h
+++ b/hardware/msp430/cores/msp430/usci_isr_handler.h
@@ -10,8 +10,8 @@ extern "C" {
 #endif
 void uart_tx_isr(uint8_t offset);
 void uart_rx_isr(uint8_t offset);
-void i2c_txrx_isr(void);
-void i2c_state_isr(void);
+uint16_t i2c_txrx_isr(void);
+uint16_t i2c_state_isr(void);
 void usci_isr_install(void);
 #ifdef __cplusplus
 }

--- a/hardware/msp430/cores/msp430/wiring_digital.c
+++ b/hardware/msp430/cores/msp430/wiring_digital.c
@@ -82,6 +82,7 @@ void pinMode(uint8_t pin, uint8_t mode)
 
 	if (mode == INPUT) {
 		*dir &= ~bit;
+        *ren &= ~bit;
 	} else if (mode == INPUT_PULLUP) {
 		*dir &= ~bit;
                 *out |= bit;
@@ -121,6 +122,8 @@ void pinMode_int(uint8_t pin, uint16_t mode)
 		} else if (mode & INPUT_PULLDOWN) {
 			*out &= ~bit;
 			*ren |= bit;
+		} else {
+	        *ren &= ~bit;
 		}
 	}
 

--- a/hardware/msp430/variants/launchpad/pins_energia.h
+++ b/hardware/msp430/variants/launchpad/pins_energia.h
@@ -41,8 +41,8 @@ static const uint8_t SS      = 8;  /* P2.0 */
 static const uint8_t SCK     = 7;  /* P1.5 */
 static const uint8_t MOSI    = 15; /* P1.7 */
 static const uint8_t MISO    = 14; /* P1.6 */
-static const uint8_t TWISDA  = 15;  /* P1.6 */
-static const uint8_t TWISCL  = 14;  /* P1.7 */
+static const uint8_t TWISDA  = 15;  /* P1.7 */
+static const uint8_t TWISCL  = 14;  /* P1.6 */
 static const uint8_t DEBUG_UARTRXD = 3;  /* Receive  Data (RXD) at P1.1 */
 static const uint8_t DEBUG_UARTTXD = 4;  /* Transmit Data (TXD) at P1.2 */
 #define TWISDA_SET_MODE  (PORT_SELECTION0 | PORT_SELECTION1 /* | INPUT_PULLUP*/) /* do not enable the pull ups for this device */
@@ -59,8 +59,8 @@ static const uint8_t DEBUG_UARTTXD = 4;  /* Transmit Data (TXD) at P1.2 */
 #if defined(__MSP430_HAS_USI__)
 static const uint8_t SS      = 8;  /* P2.0 */
 static const uint8_t SCK     = 7;  /* P1.5 */
-static const uint8_t MOSI    = 15; /* P1.6 */
-static const uint8_t MISO    = 14; /* P1.7 */
+static const uint8_t MOSI    = 15; /* P1.7 */
+static const uint8_t MISO    = 14; /* P1.6 */
 static const uint8_t TWISDA  = 15; /* P1.7 */
 static const uint8_t TWISCL  = 14; /* P1.6 */
 static const uint8_t DEBUG_UARTRXD = 4;  /* Receive  Data (RXD) at P1.2 */

--- a/hardware/msp430/variants/launchpad/pins_energia.h
+++ b/hardware/msp430/variants/launchpad/pins_energia.h
@@ -1,9 +1,9 @@
 /*
   ************************************************************************
-  *	pins_energia.h
+  *   pins_energia.h
   *
-  *	Energia core files for MSP430
-  *		Copyright (c) 2012 Robert Wessels. All right reserved.
+  *   Energia core files for MSP430
+  *      Copyright (c) 2012 Robert Wessels. All right reserved.
   *
   *     Contribution: Rei VILO
   *
@@ -41,8 +41,8 @@ static const uint8_t SS      = 8;  /* P2.0 */
 static const uint8_t SCK     = 7;  /* P1.5 */
 static const uint8_t MOSI    = 15; /* P1.7 */
 static const uint8_t MISO    = 14; /* P1.6 */
-static const uint8_t TWISDA  = 14;  /* P1.6 */
-static const uint8_t TWISCL  = 15;  /* P1.7 */
+static const uint8_t TWISDA  = 15;  /* P1.6 */
+static const uint8_t TWISCL  = 14;  /* P1.7 */
 static const uint8_t DEBUG_UARTRXD = 3;  /* Receive  Data (RXD) at P1.1 */
 static const uint8_t DEBUG_UARTTXD = 4;  /* Transmit Data (TXD) at P1.2 */
 #define TWISDA_SET_MODE  (PORT_SELECTION0 | PORT_SELECTION1 /* | INPUT_PULLUP*/) /* do not enable the pull ups for this device */
@@ -57,12 +57,12 @@ static const uint8_t DEBUG_UARTTXD = 4;  /* Transmit Data (TXD) at P1.2 */
 #define DEBUG_UART_MODULE_OFFSET 0x0
 
 #if defined(__MSP430_HAS_USI__)
-static const uint8_t SS   = 8;  /* P2.0 */
-static const uint8_t SCK  = 7;  /* P1.5 */
-static const uint8_t MOSI = 14; /* P1.6 */
-static const uint8_t MISO = 15; /* P1.7 */
-static const uint8_t TWISDA  = 14;  /* P1.7 */
-static const uint8_t TWISCL  = 15;  /* P1.6 */
+static const uint8_t SS      = 8;  /* P2.0 */
+static const uint8_t SCK     = 7;  /* P1.5 */
+static const uint8_t MOSI    = 15; /* P1.6 */
+static const uint8_t MISO    = 14; /* P1.7 */
+static const uint8_t TWISDA  = 15; /* P1.7 */
+static const uint8_t TWISCL  = 14; /* P1.6 */
 static const uint8_t DEBUG_UARTRXD = 4;  /* Receive  Data (RXD) at P1.2 */
 static const uint8_t DEBUG_UARTTXD = 3;  /* Transmit Data (TXD) at P1.1 */
 #define TWISDA_SET_MODE  (PORT_SELECTION0 | INPUT_PULLUP)
@@ -128,64 +128,64 @@ static const uint8_t TEMPSENSOR = 128 + 10; // depends on chip
 #ifdef ARDUINO_MAIN
 
 const uint16_t port_to_input[] = {
-	NOT_A_PORT,
-	(uint16_t) &P1IN,
-	(uint16_t) &P2IN,
+   NOT_A_PORT,
+   (uint16_t) &P1IN,
+   (uint16_t) &P2IN,
 #ifdef __MSP430_HAS_PORT3_R__
-	(uint16_t) &P3IN,
+   (uint16_t) &P3IN,
 #endif
 };
 
 const uint16_t port_to_output[] = {
-	NOT_A_PORT,
-	(uint16_t) &P1OUT,
-	(uint16_t) &P2OUT,
+   NOT_A_PORT,
+   (uint16_t) &P1OUT,
+   (uint16_t) &P2OUT,
 #ifdef __MSP430_HAS_PORT3_R__
-	(uint16_t) &P3OUT,
+   (uint16_t) &P3OUT,
 #endif
 };
 
 const uint16_t port_to_dir[] = {
-	NOT_A_PORT,
-	(uint16_t) &P1DIR,
-	(uint16_t) &P2DIR,
+   NOT_A_PORT,
+   (uint16_t) &P1DIR,
+   (uint16_t) &P2DIR,
 #ifdef __MSP430_HAS_PORT3_R__
-	(uint16_t) &P3DIR,
+   (uint16_t) &P3DIR,
 #endif
 };
 
 const uint16_t port_to_ren[] = {
-	NOT_A_PORT,
-	(uint16_t) &P1REN,
-	(uint16_t) &P2REN,
+   NOT_A_PORT,
+   (uint16_t) &P1REN,
+   (uint16_t) &P2REN,
 #ifdef __MSP430_HAS_PORT3_R__
-	(uint16_t) &P3REN,
+   (uint16_t) &P3REN,
 #endif
 };
 
 const uint16_t port_to_sel0[] = {  /* put this PxSEL register under the group of PxSEL0 */
-	NOT_A_PORT,
-	(uint16_t) &P1SEL,
-	(uint16_t) &P2SEL,
+   NOT_A_PORT,
+   (uint16_t) &P1SEL,
+   (uint16_t) &P2SEL,
 #ifdef __MSP430_HAS_PORT3_R__
-	(uint16_t) &P3SEL,
+   (uint16_t) &P3SEL,
 #endif
 };
 
 const uint16_t port_to_sel2[] = {
-	NOT_A_PORT,
+   NOT_A_PORT,
 #ifdef P1SEL2_
-	(uint16_t) &P1SEL2,
+   (uint16_t) &P1SEL2,
 #else
         NOT_A_PORT,
 #endif
 #ifdef P2SEL2_
-	(uint16_t) &P2SEL2,
+   (uint16_t) &P2SEL2,
 #else 
         NOT_A_PORT,
 #endif
 #ifdef P3SEL2_
-	(uint16_t) &P3SEL2,
+   (uint16_t) &P3SEL2,
 #else
         NOT_A_PORT,
 #endif
@@ -197,107 +197,107 @@ const uint16_t port_to_sel2[] = {
  * T0A1, T1A1 and T1A2 
  */
 const uint8_t digital_pin_to_timer[] = {
-	NOT_ON_TIMER, /*  dummy */
-	NOT_ON_TIMER, /*  1 - VCC */
-	NOT_ON_TIMER, /*  2 - P1.0 */
-	T0A0,         /*  3 - P1.1, note: A0 output cannot be used with analogWrite */
-	T0A1,         /*  4 - P1.2 */
-	NOT_ON_TIMER, /*  5 - P1.3 */
-	NOT_ON_TIMER, /*  6 - P1.4 note: special case. Leaving as no timer due to difficulty determining if available */
-	T0A0,         /*  7 - P1.5 note: A0 output cannot be used with analogWrite  */
+   NOT_ON_TIMER, /*  dummy */
+   NOT_ON_TIMER, /*  1 - VCC */
+   NOT_ON_TIMER, /*  2 - P1.0 */
+   T0A0,         /*  3 - P1.1, note: A0 output cannot be used with analogWrite */
+   T0A1,         /*  4 - P1.2 */
+   NOT_ON_TIMER, /*  5 - P1.3 */
+   NOT_ON_TIMER, /*  6 - P1.4 note: special case. Leaving as no timer due to difficulty determining if available */
+   T0A0,         /*  7 - P1.5 note: A0 output cannot be used with analogWrite  */
 #if defined(__MSP430_HAS_T1A3__) 
-	T1A0,         /*  8 - P2.0 note: A0 output cannot be used with analogWrite */
-	T1A1,         /*  9 - P2.1 */
-	T1A1,         /* 10 - P2.2 */
-	T1A0,         /* 11 - P2.3 note: A0 output cannot be used with analogWrite  */
-	T1A2,         /* 12 - P2.4 */
-	T1A2,         /* 13 - P2.5 */
+   T1A0,         /*  8 - P2.0 note: A0 output cannot be used with analogWrite */
+   T1A1,         /*  9 - P2.1 */
+   T1A1,         /* 10 - P2.2 */
+   T1A0,         /* 11 - P2.3 note: A0 output cannot be used with analogWrite  */
+   T1A2,         /* 12 - P2.4 */
+   T1A2,         /* 13 - P2.5 */
 #else
-	NOT_ON_TIMER, /*  8 - P2.0 */
-	NOT_ON_TIMER, /*  9 - P2.1 */
-	NOT_ON_TIMER, /* 10 - P2.3 */
-	NOT_ON_TIMER, /* 11 - P2.4 */
-	NOT_ON_TIMER, /* 12 - P2.5 */
-	NOT_ON_TIMER, /* 13 - P2.6 */
+   NOT_ON_TIMER, /*  8 - P2.0 */
+   NOT_ON_TIMER, /*  9 - P2.1 */
+   NOT_ON_TIMER, /* 10 - P2.3 */
+   NOT_ON_TIMER, /* 11 - P2.4 */
+   NOT_ON_TIMER, /* 12 - P2.5 */
+   NOT_ON_TIMER, /* 13 - P2.6 */
 #endif
-	T0A1,         /* 14 - P1.6 */
-	NOT_ON_TIMER, /* 15 - P1.7 */
-	NOT_ON_TIMER, /* 16 - /RESET */  
-	NOT_ON_TIMER, /* 17 - TEST */  
-	NOT_ON_TIMER, /* 18 - XOUT - P2.7 */
-	T0A1,         /* 19 - XIN - P2.6: */
-	NOT_ON_TIMER, /* 20 - GND */
+   T0A1,         /* 14 - P1.6 */
+   NOT_ON_TIMER, /* 15 - P1.7 */
+   NOT_ON_TIMER, /* 16 - /RESET */  
+   NOT_ON_TIMER, /* 17 - TEST */  
+   NOT_ON_TIMER, /* 18 - XOUT - P2.7 */
+   T0A1,         /* 19 - XIN - P2.6: */
+   NOT_ON_TIMER, /* 20 - GND */
 };
 
 const uint8_t digital_pin_to_port[] = {
-	NOT_A_PIN, /* dummy */
-	NOT_A_PIN, /* 1 */
-	P1, /* 2 */
-	P1, /* 3 */
-	P1, /* 4 */
-	P1, /* 5 */
-	P1, /* 6 */
-	P1, /* 7 */
-	P2, /* 8 */
-	P2, /* 9 */
-	P2, /* 10 */
-	P2, /* 11 */
-	P2, /* 12 */
-	P2, /* 13 */
-	P1, /* 14 */
-	P1, /* 15 */
-	NOT_A_PIN, /* 16 */
-	NOT_A_PIN, /* 17 */
-	P2, /* 18 */
-	P2, /* 19 */
-	NOT_A_PIN, /* 20 */
+   NOT_A_PIN, /* dummy */
+   NOT_A_PIN, /* 1 */
+   P1, /* 2 */
+   P1, /* 3 */
+   P1, /* 4 */
+   P1, /* 5 */
+   P1, /* 6 */
+   P1, /* 7 */
+   P2, /* 8 */
+   P2, /* 9 */
+   P2, /* 10 */
+   P2, /* 11 */
+   P2, /* 12 */
+   P2, /* 13 */
+   P1, /* 14 */
+   P1, /* 15 */
+   NOT_A_PIN, /* 16 */
+   NOT_A_PIN, /* 17 */
+   P2, /* 18 */
+   P2, /* 19 */
+   NOT_A_PIN, /* 20 */
 };
 
 const uint8_t digital_pin_to_bit_mask[] = {
-	NOT_A_PIN, /* 0,  pin count starts at 1 */
-	NOT_A_PIN, /* 1,  VCC */
-	BV(0),     /* 2,  port P1.0 */
-	BV(1),     /* 3,  port P1.1 */
-	BV(2),     /* 4,  port P1.2 */
-	BV(3),     /* 5,  port P1.3*/
-	BV(4),     /* 6,  port P1.4 */
-	BV(5),     /* 7,  port P1.5 */
-	BV(0),     /* 8,  port P2.0 */
-	BV(1),     /* 9,  port P2.1 */
-	BV(2),     /* 10, port P2.2 */
-	BV(3),     /* 11, port P2.3 */
-	BV(4),     /* 12, port P2.4 */
-	BV(5),     /* 13, port P2.5 */
-	BV(6),     /* 14, port P1.6 */
-	BV(7),     /* 15, port P1.7 */
-	NOT_A_PIN, /* 16, RST */
-	NOT_A_PIN, /* 17, TEST */
-	BV(7),     /* 18, XOUT */
-	BV(6),     /* 19, XIN */
-	NOT_A_PIN, /* 20, GND */
+   NOT_A_PIN, /* 0,  pin count starts at 1 */
+   NOT_A_PIN, /* 1,  VCC */
+   BV(0),     /* 2,  port P1.0 */
+   BV(1),     /* 3,  port P1.1 */
+   BV(2),     /* 4,  port P1.2 */
+   BV(3),     /* 5,  port P1.3*/
+   BV(4),     /* 6,  port P1.4 */
+   BV(5),     /* 7,  port P1.5 */
+   BV(0),     /* 8,  port P2.0 */
+   BV(1),     /* 9,  port P2.1 */
+   BV(2),     /* 10, port P2.2 */
+   BV(3),     /* 11, port P2.3 */
+   BV(4),     /* 12, port P2.4 */
+   BV(5),     /* 13, port P2.5 */
+   BV(6),     /* 14, port P1.6 */
+   BV(7),     /* 15, port P1.7 */
+   NOT_A_PIN, /* 16, RST */
+   NOT_A_PIN, /* 17, TEST */
+   BV(7),     /* 18, XOUT */
+   BV(6),     /* 19, XIN */
+   NOT_A_PIN, /* 20, GND */
 };
 const uint32_t digital_pin_to_analog_in[] = {
         NOT_ON_ADC,     /*  dummy   */
         NOT_ON_ADC,     /*  1 - 3.3V*/
-        0,				/*  2 - A0 */
-        1,     			/*  3 - A1 */
-        2, 				/*  4 - A2 */
-        3, 				/*  5 - A3 */
-        4, 				/*  6 - A4 */
-        5,   			/*  7 - A5 */
-        NOT_ON_ADC, 	/*  8 - P2.0 */
-        NOT_ON_ADC, 	/*  9 - P2.1 */
-        NOT_ON_ADC, 	/*  10 - P2.2 */
-        NOT_ON_ADC, 	/*  11 - P2.3 */
-        NOT_ON_ADC, 	/*  12 - P2.4 */
-        NOT_ON_ADC, 	/*  13 - P2.5 */
-        6,     			/*  14 - A6 */
-        7,     			/*  15 - A7 */
-        NOT_ON_ADC, 	/*  16 - RST */
+        0,            /*  2 - A0 */
+        1,              /*  3 - A1 */
+        2,             /*  4 - A2 */
+        3,             /*  5 - A3 */
+        4,             /*  6 - A4 */
+        5,            /*  7 - A5 */
+        NOT_ON_ADC,    /*  8 - P2.0 */
+        NOT_ON_ADC,    /*  9 - P2.1 */
+        NOT_ON_ADC,    /*  10 - P2.2 */
+        NOT_ON_ADC,    /*  11 - P2.3 */
+        NOT_ON_ADC,    /*  12 - P2.4 */
+        NOT_ON_ADC,    /*  13 - P2.5 */
+        6,              /*  14 - A6 */
+        7,              /*  15 - A7 */
+        NOT_ON_ADC,    /*  16 - RST */
         NOT_ON_ADC,     /*  17 - PF0 */
-        NOT_ON_ADC, 	/*  18 - PE0 */
+        NOT_ON_ADC,    /*  18 - PE0 */
         NOT_ON_ADC,     /*  19 - PB2 */
-        NOT_ON_ADC  	/*  20 - GND */
+        NOT_ON_ADC     /*  20 - GND */
 };
 
 #endif


### PR DESCRIPTION
Please merge in the updates for the wire lib.
I did a lot of cleanup and try the changes on the FR5969, FR6989; FR4133, G2553 F5529 and G245x
with the master and slave code and the BMP180 examples.
So far i could not see any issue any more.
The fixes contains:
 updates to the wire lib
 update in the comments for the launchpad pin file
 update in the digital lib to enable clearing the pull up down feature of the port pins
 proper handling of the low power mode clear in the ISR of the I2C functions
