### PR TITLE
CC3200: Fix  Bssid Getting function - bssid is copied to argument array

### DIFF
--- a/hardware/cc3200/libraries/WiFi/WiFi.cpp
+++ b/hardware/cc3200/libraries/WiFi/WiFi.cpp
@@ -68,7 +68,7 @@ volatile wlanAttachedDevice_t WiFiClass::_connectedDevices[MAX_AP_DEVICE_REGISTR
 //initialize the ssid and bssid to blank and 0s respectively
 //
 char WiFiClass::connected_ssid[32] = "";
-unsigned char WiFiClass::connected_bssid[6] = {0,0,0,0,0,0};
+unsigned char WiFiClass::connected_bssid[BSSID_LEN] = {0,0,0,0,0,0};
 
 //
 //a better way of keeping track of servers, clients, ports, and handles
@@ -744,11 +744,14 @@ uint8_t* WiFiClass::BSSID(uint8_t* bssid)
         init();
     }
     //
-    //because the bssid 6 char array is maintained by the callback
-    //passing in a 6 char array is unecessary and only kept for
-    //compatability with the Arduino WiFi library
+    //Get the mac address and return the pointer to the array
     //
-    return WiFiClass::connected_bssid;
+	if (bssid !=0){//check for nullptr
+		for (uint8_t i = 0; i < BSSID_LEN ; i++){//copy
+			bssid[i] = WiFiClass::connected_bssid[i];
+		}
+	}
+    return bssid;
     
 }
 

--- a/hardware/cc3200emt/libraries/WiFi/WiFi.cpp
+++ b/hardware/cc3200emt/libraries/WiFi/WiFi.cpp
@@ -69,7 +69,7 @@ volatile wlanAttachedDevice_t WiFiClass::_connectedDevices[MAX_AP_DEVICE_REGISTR
 //initialize the ssid and bssid to blank and 0s respectively
 //
 char WiFiClass::connected_ssid[32] = "";
-unsigned char WiFiClass::connected_bssid[6] = {0,0,0,0,0,0};
+unsigned char WiFiClass::connected_bssid[BSSID_LEN] = {0,0,0,0,0,0};
 
 //
 //a better way of keeping track of servers, clients, ports, and handles
@@ -745,11 +745,14 @@ uint8_t* WiFiClass::BSSID(uint8_t* bssid)
         init();
     }
     //
-    //because the bssid 6 char array is maintained by the callback
-    //passing in a 6 char array is unecessary and only kept for
-    //compatability with the Arduino WiFi library
+    //Get the mac address and return the pointer to the array
     //
-    return WiFiClass::connected_bssid;
+	if (bssid !=0){//check for nullptr
+		for (uint8_t i = 0; i < BSSID_LEN ; i++){//copy
+			bssid[i] = WiFiClass::connected_bssid[i];
+		}
+	}
+    return bssid;
     
 }
 


### PR DESCRIPTION
in CC3200 launchpad WiFi.BSSID(); function did not copy bssid to argument array and you have to use returned pointer to read it.
Now it work as macAddress() and other default examples
byte bssid[6];
WiFi.BSSID(bssid);