### PR TITLE
Update LCD_SharpBoosterPack_SPI.cpp

### DIFF
--- a/libraries/LCD_SharpBoosterPack_SPI/LCD_SharpBoosterPack_SPI.cpp
+++ b/libraries/LCD_SharpBoosterPack_SPI/LCD_SharpBoosterPack_SPI.cpp
@@ -17,7 +17,7 @@
 //  Licence CC = BY SA NC
 //
 
-#include <energia.h>
+#include <Energia.h>
 #include "LCD_SharpBoosterPack_SPI.h"
 #include "SPI.h"
 


### PR DESCRIPTION
it should be "Energia.h"  (with capital E) in the include declaration, won't compile with "energia.h".