### PR TITLE
OPT3001 Library changes

### DIFF
--- a/libraries/OPT3001/OPT3001.cpp
+++ b/libraries/OPT3001/OPT3001.cpp
@@ -27,19 +27,19 @@
 					01 = Single shot mode
 					10 = Continuous conversion (default)
 					11 = Continuous conversion
-	OVF (Bit 8)	– 	Overflow flag. When set the conversion result is overflown.
-	CRF (Bit 7)	–	Conversion ready flag. Sets at end of conversion. Clears by read or write of the Configuration register.
-	FH (Bit 6)	– 	Flag high bit. Read only. Sets when result is higher that TH register. Clears when Config register is 
-					read or when Latch bit is ‘0’ and the result goes bellow TH register.
-	FL (Bit 5)	– 	Flag low bit. Read only. Sets when result is lower that TL register. Clears when Config register is read 
-					or when Latch bit is ‘0’ and the result goes above TL register.
-	L (Bit 4) 	–	Latch bit. Read/write bit. Default ‘1’, Controls Latch/transparent functionality of FH and FL bits. When 
+	OVF (Bit 8)	â€“ 	Overflow flag. When set the conversion result is overflown.
+	CRF (Bit 7)	â€“	Conversion ready flag. Sets at end of conversion. Clears by read or write of the Configuration register.
+	FH (Bit 6)	â€“ 	Flag high bit. Read only. Sets when result is higher that TH register. Clears when Config register is 
+					read or when Latch bit is â€˜0â€™ and the result goes bellow TH register.
+	FL (Bit 5)	â€“ 	Flag low bit. Read only. Sets when result is lower that TL register. Clears when Config register is read 
+					or when Latch bit is â€˜0â€™ and the result goes above TL register.
+	L (Bit 4) 	â€“	Latch bit. Read/write bit. Default â€˜1â€™, Controls Latch/transparent functionality of FH and FL bits. When 
 					L = 1 the Alert pin works in window comparator mode with Latched functionality When L = 0 the Alert pin 
 					works in transparent mode and the two limit registers provide the hysteresis.
-	Pol (Bit 3)	–	Polarity. Read/write bit. Default ‘0’, Controls the active state of the Alert pin. Pol = 0 means Alert 
+	Pol (Bit 3)	â€“	Polarity. Read/write bit. Default â€˜0â€™, Controls the active state of the Alert pin. Pol = 0 means Alert 
 					active low.
-	ME (Bit 2)	–	Exponent mask. In fixed range modes masks the exponent bits in the result register to “0000”.
-	FC1 to FC0	-	Fault count bits. Read/write bits. Default “00” - the first fault will trigger the alert pin.
+	ME (Bit 2)	â€“	Exponent mask. In fixed range modes masks the exponent bits in the result register to â€œ0000â€.
+	FC1 to FC0	-	Fault count bits. Read/write bits. Default â€œ00â€ - the first fault will trigger the alert pin.
 */
 
 void opt3001::begin()
@@ -71,9 +71,9 @@ void opt3001::begin()
 
 uint16_t opt3001::readRegister(uint8_t registerName)
 {
-	int8_t lsb;
-	int8_t msb;
-	int16_t result;
+	uint8_t lsb;
+	uint8_t msb;
+	uint16_t result;
 
 
 	// Initialize Wire
@@ -138,7 +138,7 @@ uint32_t opt3001::readResult()
 {
 	uint16_t exponent = 0;
 	uint32_t result = 0;
-	int16_t raw;
+	uint16_t raw;
 	raw = readRegister(RESULT_REG);
 	
 	/*Convert to LUX*/
@@ -147,44 +147,8 @@ uint32_t opt3001::readResult()
 	exponent = (raw>>12)&0x000F;
 
 	//convert raw readings to LUX
-	switch(exponent){
-		case 0: //*0.015625
-			result = result>>6;
-			break;
-		case 1: //*0.03125
-			result = result>>5;
-			break;
-		case 2: //*0.0625
-			result = result>>4;
-			break;
-		case 3: //*0.125
-			result = result>>3;
-			break;
-		case 4: //*0.25
-			result = result>>2;
-			break;
-		case 5: //*0.5
-			result = result>>1;
-			break;
-		case 6:
-			result = result;
-			break;
-		case 7: //*2
-			result = result<<1;
-			break;
-		case 8: //*4
-			result = result<<2;
-			break;
-		case 9: //*8
-			result = result<<3;
-			break;
-		case 10: //*16
-			result = result<<4;
-			break;
-		case 11: //*32
-			result = result<<5;
-			break;
-	}
+	result = result << exponent;
+	result = ((((result*divisor)>>16)+result)>>1)>>6;
 
 	return result;
 	

--- a/libraries/OPT3001/OPT3001.cpp
+++ b/libraries/OPT3001/OPT3001.cpp
@@ -140,6 +140,7 @@ uint32_t opt3001::readResult()
 	uint32_t result = 0;
 	uint16_t raw;
 	raw = readRegister(RESULT_REG);
+	uint16_t divisor = 0x47AF;
 	
 	/*Convert to LUX*/
 	//extract result & exponent data from raw readings


### PR DESCRIPTION
The OPT3001 sensor did not function properly prior to these changes.  The values would jump around due to sign extension when reading the values from the register through I2C.  Additionally, the bit shifting done to the value read resulted in very differential LUX readings from what were intended.  With the new math, the readings are much more accurate compared to the intended values that were obtained using the OPT3001 EVM.  