### PR TITLE
analogReadResolution() not available on all LaunchPads

### DIFF
--- a/hardware/cc3200/cores/cc3200/Energia.h
+++ b/hardware/cc3200/cores/cc3200/Energia.h
@@ -110,6 +110,7 @@ void pinMode(uint8_t, uint8_t);
 void digitalWrite(uint8_t, uint8_t);
 int digitalRead(uint8_t);
 uint16_t analogRead(uint8_t);
+void analogReadResolution(int res);
 void analogWrite(uint8_t, int);
 void analogReference(uint16_t);
 void analogFrequency(uint32_t);

--- a/hardware/cc3200/cores/cc3200/wiring_analog.c
+++ b/hardware/cc3200/cores/cc3200/wiring_analog.c
@@ -42,6 +42,8 @@
 #define TIMER_INTERVAL_RELOAD   40035//255*157
 #define DUTYCYCLE_GRANULARITY   157
 
+static int _readResolution = 12;
+
 void PWMWrite(uint8_t pin, uint32_t analog_res, uint32_t duty, uint32_t freq)
 {
 	analog_res = analog_res * 1000;
@@ -129,6 +131,19 @@ void analogWrite(uint8_t pin, int val) {
 	PWMWrite(pin, 255, val, 490);
 }
 
+void analogReadResolution(int res) {
+    _readResolution = res;
+}
+
+static inline uint32_t mapResolution(uint32_t value, uint32_t from, uint32_t to) {
+    if (from == to)
+        return value;
+    if (from > to)
+        return value >> (from-to);
+    else
+        return value << (to-from);
+}
+
 uint16_t analogRead(uint8_t pin)
 {
     uint16_t channel,val;
@@ -160,6 +175,6 @@ uint16_t analogRead(uint8_t pin)
     ADCTimerDisable(ADC_BASE);
 
     val = val >> 2;
-    return val;
+    return mapResolution(val, 12, _readResolution);
 }
 

--- a/hardware/lm4f/cores/lm4f/Energia.h
+++ b/hardware/lm4f/cores/lm4f/Energia.h
@@ -221,6 +221,7 @@ void pinMode(uint8_t, uint8_t);
 void digitalWrite(uint8_t, uint8_t);
 int digitalRead(uint8_t);
 uint16_t analogRead(uint8_t);
+void analogReadResolution(int res);
 void analogWrite(uint8_t, int);
 void analogReference(uint16_t);
 void analogFrequency(uint32_t);

--- a/hardware/lm4f/cores/lm4f/wiring_analog.c
+++ b/hardware/lm4f/cores/lm4f/wiring_analog.c
@@ -43,6 +43,7 @@
 
 
 #define PWM_MODE 0x20A
+static int _readResolution = 12;
 
 #ifdef __TM4C1294NCPDT__
 uint32_t getTimerBase(uint32_t offset) {
@@ -175,6 +176,19 @@ void analogWrite(uint8_t pin, int val) {
     PWMWrite(pin, 255, val, 490);
 }
 
+void analogReadResolution(int res) {
+    _readResolution = res;
+}
+
+static inline uint32_t mapResolution(uint32_t value, uint32_t from, uint32_t to) {
+    if (from == to)
+        return value;
+    if (from > to)
+        return value >> (from-to);
+    else
+        return value << (to-from);
+}
+
 uint16_t analogRead(uint8_t pin) {
     uint8_t port = digitalPinToPort(pin);
     uint16_t value[1];
@@ -195,5 +209,6 @@ uint16_t analogRead(uint8_t pin) {
     }
 	ROM_ADCIntClear(ADC0_BASE, 3);
     ROM_ADCSequenceDataGet(ADC0_BASE, 3, (unsigned long*) value);
-    return value[0];
+
+    return mapResolution(value[0], 12, _readResolution);
 }

--- a/hardware/msp430/cores/msp430/Energia.h
+++ b/hardware/msp430/cores/msp430/Energia.h
@@ -194,6 +194,7 @@ void pinMode(uint8_t, uint8_t);
 void pinMode_int(uint8_t, uint16_t);
 void digitalWrite(uint8_t, uint8_t);
 int digitalRead(uint8_t);
+void analogReadResolution(int res);
 uint16_t analogRead(uint8_t);
 void analogWrite(uint8_t, int);
 void analogReference(uint16_t);


### PR DESCRIPTION
This API should be enabled on all LaunchPads. Since there are different ADC resolutions available across the LaunchPad ecosystem, using the analogReadResolution() within example sketches will help improve code portability.

I tried to use this API on the MSP-EXP430F5529LP LaunchPad, but was not able to. 

Thanks!