### PR TITLE
MSP430 USI SPI Library: pins should be released after SPI.end()

### DIFF
--- a/hardware/msp430/libraries/SPI/utility/usi_spi.cpp
+++ b/hardware/msp430/libraries/SPI/utility/usi_spi.cpp
@@ -62,6 +62,7 @@ void spi_initialize(void)
 
 void spi_disable(void) {
     USICTL0 |= USISWRST;        // put USI in reset mode
+    USICTL0 &= ~(USIPE5 | USIPE6 | USIPE7);
 }
 
 /**


### PR DESCRIPTION
MOSI, MISO and SCK pins should be released from SPI hardware when SPI.end() called. Otherwise you can not use these pins for something else after spi transmission done.