### PR TITLE
Add option to use client certificate with sslConnect

### DIFF
--- a/hardware/cc3200/libraries/WiFi/WiFiClient.h
+++ b/hardware/cc3200/libraries/WiFi/WiFiClient.h
@@ -44,7 +44,8 @@ public:
     virtual int sslConnect(const char *host, uint16_t port);
     // SSL root CA verification is a work in progress
     //virtual int sslRootCA(const uint8_t *rootCAfilecontents, const size_t);
-    //virtual int useRootCA(void);
+    virtual byte useRootCA(void);
+    virtual byte useClientCert(void);
     //virtual void sslStrict(boolean);
     //virtual int32_t sslGetReasonID(void);
     //virtual const char *sslGetReason(void);
@@ -70,6 +71,7 @@ protected:
     int rx_currentIndex;
     boolean sslVerifyStrict;
     boolean hasRootCA;
+    boolean hasClientCert;
     int32_t sslLastError;
 };
 


### PR DESCRIPTION
This small fix allows WiFiClients sslConnect to communicate with services that require client to provide certificate. Tested with Mosquitto MQTT with certificate based authentication.
