### PR TITLE
fix hardware i2c on USCI devices

### DIFF
--- a/hardware/msp430/cores/msp430/twi.c
+++ b/hardware/msp430/cores/msp430/twi.c
@@ -135,7 +135,7 @@ static uint8_t twi_my_addr;
 #define UCBxI2CSA     (*((volatile uint8_t *)((uint16_t)(I2C_baseAddress + UCB0I2CSA_  - UCB0_BASE)))) 
 
 #define UCxIE         UC0IE
-#define UCBxI2CIE     UC0IE
+#define UCBxI2CIE     (*((volatile uint8_t *)((uint16_t)(I2C_baseAddress + UCB0I2CIE_  - UCB0_BASE)))) 
 #define UCxIFG        UC0IFG
 #if defined(UCB1RXIE)
 #define UCBxRXIE      UCB0RXIE  ? (I2C_baseAddress == UCB0_BASE) : UCB1RXIE


### PR DESCRIPTION
The I2C interrupt enable register address define got the wrong value. This was introduced by 4204d2ee9cea01624dcef4761243987169e40128

Signed-off-by: itserik <itserik@gmail.com>