### PR TITLE
Add NSHighResolutionCapable

### DIFF
--- a/build/macosx/template.app/Contents/Info.plist
+++ b/build/macosx/template.app/Contents/Info.plist
@@ -92,5 +92,7 @@
 			<string>true</string>
 		</dict>
 	</dict>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Allow Retina display mode instead of pixel doubling for the IDE on Mac OS X. Some antialiasing issues persist but seems to have no ill effects.

Similar to the change made in Arduino as part of https://github.com/arduino/Arduino/issues/2309