### PR TITLE
Edits to EduMKII BP Examples

### DIFF
--- a/build/shared/examples/09.EducationalBP_MKII/AccelerometerLED/AccelerometerLED.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/AccelerometerLED/AccelerometerLED.ino
@@ -40,10 +40,7 @@ const int greenLED= 38;// assign green LED to Pin #10
 const int blueLED= 37; // assign blueLED to Pin #12
 
 void setup() {
-    // By default MSP432 has analogRead() set to 10 bits. 
-    // This Sketch assumes 12 bits. Uncomment to line below to set analogRead()
-    // to 12 bit resolution for MSP432.
-    //analogReadResolution(12);
+    analogReadResolution(12); //added to ensure a 12 bit analog read resolution
     Serial.begin(9600); // initialize for sending diagnostic info to computer
 }
 

--- a/build/shared/examples/09.EducationalBP_MKII/AccelerometerSerial/AccelerometerSerial.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/AccelerometerSerial/AccelerometerSerial.ino
@@ -41,10 +41,7 @@ const int zpin = 25;                  // z-axis (only on 3-axis models)
 
 void setup()
 {
-  // By default MSP432 has analogRead() set to 10 bits. 
-  // This Sketch assumes 12 bits. Uncomment to line below to set analogRead()
-  // to 12 bit resolution for MSP432.
-  //analogReadResolution(12);
+  analogReadResolution(12); //added to ensure a 12 bit analog read resolution
 
   // initialize the serial communications:
   Serial.begin(9600);

--- a/build/shared/examples/09.EducationalBP_MKII/EduBP_MKII_Production_Test/EduBP_MKII_Production_Test.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/EduBP_MKII_Production_Test/EduBP_MKII_Production_Test.ino
@@ -1,9 +1,11 @@
 
+
+
 #include "pitches.h"
 #include <itoa.h>
 #include <Wire.h>
 #include <Adafruit_TMP006.h>
-//#include "OPT3001.h"
+#include "OPT3001.h"
 #define USE_USCI_B1 
 #define USING_MSP430F5529_LAUNCHPAD
 //#define USING_TIVA_C_LAUNCHPAD
@@ -281,7 +283,7 @@ float tempReading = 0;
 #define NOTE_C4_1 260
 
 // OPT3001
-//opt3001 opt3001;
+opt3001 opt3001;
 Adafruit_TMP006 tmp006;
 unsigned long readings = 0;
 
@@ -302,6 +304,7 @@ int noteDurations[] = {
 void setup()
 {
   // put your setup code here, to run once:
+  analogReadResolution(12); //added for the MSP432 to change resolution from the default 
   Serial.begin(115200);
   delay(300);
   pinMode(SEL, INPUT);
@@ -311,7 +314,7 @@ void setup()
   Serial.println("Welcome to the Educational BoosterPack MKII Production Test:");
 
   tmp006.begin(TMP006_CFG_8SAMPLE);  // Takes 8 averaged samples for measurement
-//  opt3001.begin(); 
+  opt3001.begin(); 
 }
 
 char *ftoa(char *a, float f, int precision)
@@ -369,7 +372,7 @@ void loop()
     colour = redColour;
             
 	myScreen.setOrientation(i);
-	myScreen.setFontSize(2);
+	myScreen.setFontSize(1);
 	
 	
             
@@ -377,7 +380,7 @@ void loop()
   //Test out the joystick
   myScreen.gText(0, 0, "  JoyStick Test", blueColour);
   myScreen.gText(0, 15, "Right", colour);
-  while(analogRead(JOY_X)<4094);
+  while(analogRead(JOY_X)<4085);
   
   myScreen.gText(50,15, " > Passed!", colour);
   myScreen.gText(0, 30, "Left", colour);
@@ -385,7 +388,7 @@ void loop()
   myScreen.gText(50,30, " > Passed!", colour);
   
   myScreen.gText(0, 45, "Up", colour);
-  while(analogRead(JOY_Y)<4094);
+  while(analogRead(JOY_Y)<4085);
   myScreen.gText(50,45, " > Passed!", colour);
   
   myScreen.gText(0, 60, "Down", colour);
@@ -482,19 +485,23 @@ void loop()
   myScreen.gText(0,0, "   TMP006 Test", blueColour);
   myScreen.gText(0,20, (char*)tempText , colour);
   myScreen.gText(60,20, "*C", colour);
-  
-  myScreen.gText(0,40, "   RGB LED Test", blueColour);
+  myScreen.gText(0,70, "S1 to Finish", colour);
+  while(digitalRead(SW1) == 1);
+  myScreen.clear(grayColour);
+
   //TEST OPT3001 LIGHT SENSOR
   //To be enabled once OPT3001 is added to future Edu BP MK II Rev.
-  // Serial.println("Cover the light sensor to test the OPT3001.");
-  // while(opt3001.readResult() > 30);
-  // Serial.println("Shine flashlight onto the light sensor ");
-  // while(opt3001.readResult() < 1000);
-  
-  // Serial.println("OPT3001 testing successful!");
-  
+  myScreen.gText(0,0, "   OPT3001 Test", blueColour);
+  myScreen.gText(0,20, "Cover the OPT3001", blueColour);
+  while(opt3001.readResult() > 30);
+  myScreen.gText(0,40, "Passed!", redColour);
+  myScreen.gText(0,60, "Uncover the OPT3001", blueColour);
+  while(opt3001.readResult() < 50);
+  myScreen.gText(0,80, "Passed!", redColour);
+  delay(400);
+  myScreen.clear(grayColour);
   //TEST RGB LED
-
+  myScreen.gText(0,20, "RGB LED Test", blueColour);
   i = 0;
   int brightness = 0;
   int fadeAmount = 5;
@@ -529,9 +536,9 @@ void loop()
     // wait for 30 milliseconds to see the dimming effect    
     delay(10); 
   }
-  myScreen.gText(0,70, "S1 to Finish", colour);
+  myScreen.gText(0,60, "S1 to Finish", colour);
   while(digitalRead(SW1) == 1);
-  myScreen.gText(0,90, "ALL TESTS PASSED", greenColour);
+  myScreen.gText(0,100, "ALL TESTS PASSED", greenColour);
   
   while(1);
 }

--- a/build/shared/examples/09.EducationalBP_MKII/EduBP_MKII_Production_Test_Serial/EduBP_MKII_Production_Test_Serial.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/EduBP_MKII_Production_Test_Serial/EduBP_MKII_Production_Test_Serial.ino
@@ -1,8 +1,10 @@
 
+
+
 #include "pitches.h"
 #include <Wire.h>
 #include <Adafruit_TMP006.h>
-//#include "OPT3001.h"
+#include "OPT3001.h"
 #define USE_USCI_B1 
 #define USING_MSP430F5529_LAUNCHPAD
 //#define USING_TIVA_C_LAUNCHPAD
@@ -280,7 +282,7 @@ float tempReading = 0;
 #define NOTE_C4_1 260
 
 // OPT3001
-//opt3001 opt3001;
+opt3001 opt3001;
 Adafruit_TMP006 tmp006;
 unsigned long readings = 0;
 
@@ -301,6 +303,7 @@ int noteDurations[] = {
 void setup()
 {
   // put your setup code here, to run once:
+  analogReadResolution(12); //added to ensure a 12 bit analog read resolution
   Serial.begin(115200);
   delay(300);
   pinMode(SEL, INPUT);
@@ -310,7 +313,7 @@ void setup()
   Serial.println("Welcome to the Educational BoosterPack MKII Production Test:");
 
   tmp006.begin(TMP006_CFG_8SAMPLE);  // Takes 8 averaged samples for measurement
-//  opt3001.begin(); 
+  opt3001.begin(); 
 }
 
 
@@ -322,13 +325,13 @@ void loop()
   
   //Test out the joystick
   Serial.print("Push joystick all the way to the right.");
-  while(analogRead(JOY_X)<4094);
+  while(analogRead(JOY_X)<4085);
   Serial.println(" > Passed!");
   Serial.print("Push joystick all the way to the left.");
   while(analogRead(JOY_X)>0);
   Serial.println(" > Passed!");
   Serial.print("Push joystick all the way to the top.");
-  while(analogRead(JOY_Y)<4094);
+  while(analogRead(JOY_Y)<4085);
   Serial.println(" > Passed!");
   Serial.print("Push joystick all the way to the bottom.");
   while(analogRead(JOY_Y)>0);
@@ -426,12 +429,12 @@ void loop()
   
   //TEST OPT3001 LIGHT SENSOR
   //To be enabled once OPT3001 is added to future Edu BP MK II Rev.
-  // Serial.println("Cover the light sensor to test the OPT3001.");
-  // while(opt3001.readResult() > 30);
-  // Serial.println("Shine flashlight onto the light sensor ");
-  // while(opt3001.readResult() < 1000);
+  Serial.println("Cover the light sensor to test the OPT3001.");
+  while(opt3001.readResult() > 30);
+  Serial.println("Uncover the light sensor ");
+  while(opt3001.readResult() < 50);
   
-  // Serial.println("OPT3001 testing successful!");
+  Serial.println("OPT3001 testing successful!");
   
   //TEST RGB LED
   Serial.println("Press SW1 to test the RGB LED.");

--- a/build/shared/examples/09.EducationalBP_MKII/GatorHoleBuzzer/GatorHoleBuzzer.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/GatorHoleBuzzer/GatorHoleBuzzer.ino
@@ -3,7 +3,7 @@
 http://boosterpackdepot.info/wiki/index.php?title=Educational_BoosterPack_MK_II
  
  Turn anything into an input using the Gator Holes. Connect the 
- the two Gator Holes with anything conductive (e.g. your hand, a fruit,
+ the two Gator Holes with anything conductive (e.g. a wire, a fruit,
  orange juice, coffee, etc.) to sound the Buzzer.
  
  Dec 2013 - Modified for Educational BoosterPack MK II
@@ -22,7 +22,6 @@ http://boosterpackdepot.info/wiki/index.php?title=Educational_BoosterPack_MK_II
  
  
  */
-
 const int gatorHole = 34;     // the number of the gator hole pin
 const int buzzerPin = 40;
 
@@ -33,15 +32,13 @@ void setup() {
 
   // initialize the gator hole pin as an input:
   pinMode(gatorHole, INPUT_PULLUP);     
-  
 }
 
 void loop(){
-  // read the state of the pushbutton value:
+  // read the state of the gator hole
   gatorHoleState = digitalRead(gatorHole);
-
-  // check if the pushbutton is pressed.
-  // if it is, the buttonState is HIGH:
+  // check if the gatorholes are connected.
+  // if it is, the gatorHoleState is LOW:
   if (gatorHoleState == LOW) {     
     // turn on Buzzer 
     tone(buzzerPin, 500, 500);
@@ -50,5 +47,5 @@ void loop(){
     // turn off Buzzer
     noTone(buzzerPin);
   }
-  
+  delay(5);
 }

--- a/build/shared/examples/09.EducationalBP_MKII/JoystickDrawColor/JoystickDrawColor.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/JoystickDrawColor/JoystickDrawColor.ino
@@ -38,14 +38,14 @@ byte drawColor = 0;
 boolean lastCycleState = true;
 
 void setup() {
-    // By default MSP432 has analogRead() set to 10 bits. 
-    // This Sketch assumes 12 bits. Uncomment to line below to set analogRead()
-    // to 12 bit resolution for MSP432.
-    //analogReadResolution(12);
+    
+    analogReadResolution(12); //added to ensure a 12 bit analog read resolution
 
     //Start Serial communication
     Serial.begin(9600);
-    
+    pinMode(drawButton, INPUT_PULLUP);
+    pinMode(32,INPUT_PULLUP);
+    pinMode(33,INPUT_PULLUP);
     //Initialize myScreen
     myScreen.begin();
     

--- a/build/shared/examples/09.EducationalBP_MKII/JoystickSerial/JoystickSerial.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/JoystickSerial/JoystickSerial.ino
@@ -36,10 +36,7 @@ int joystickXState, joystickYState ;
 void setup() {
 
    
-  // By default MSP432 has analogRead() set to 10 bits. 
-  // This Sketch assumes 12 bits. Uncomment to line below to set analogRead()
-  // to 12 bit resolution for MSP432.
-  //analogReadResolution(12);
+  analogReadResolution(12); //added to ensure a 12 bit analog read resolution
 
   // initialize the pushbutton pin as an input:
   pinMode(joystickSel, INPUT_PULLUP);     

--- a/build/shared/examples/09.EducationalBP_MKII/KonamiContra/KonamiContra.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/KonamiContra/KonamiContra.ino
@@ -34,6 +34,7 @@ int pressedStart(void);
 void setup()
 {
   // put your setup code here, to run once:
+  analogReadResolution(12); //added to ensure a 12 bit analog read resolution
   statemachine =0;
   pinMode(BUTTON_B, INPUT);
   pinMode(BUTTON_A, INPUT);
@@ -135,8 +136,7 @@ void loop()
       break; 
 
     //---BUTTON_B---             
-    case 8: // Waiting for Right       
-      delay(300);
+    case 8: // Waiting for buttonB       
       if (pressedB())       //Button B
           statemachine++;  
       else
@@ -144,7 +144,7 @@ void loop()
       break; 
 
     //---BUTTON_A---             
-    case 9: // Waiting for Right       
+    case 9: // Waiting for buttonA       
       if (pressedA())       //Button A
           statemachine++;  
       else
@@ -180,7 +180,7 @@ int pressedLeft(void)
          (digitalRead(JOY_SEL) == 0) )         
       pass = 0;
       
-    if ( (analogRead(JOY_Y)<10) || (analogRead(JOY_Y) >  4050) )
+    if ( (analogRead(JOY_Y)<10) || (analogRead(JOY_Y) >  4050) || (analogRead(JOY_X) > 4085)  )
       pass = 0;    
     
   }  
@@ -189,7 +189,7 @@ int pressedLeft(void)
 int pressedRight(void)
 {
   uint8_t pass  = 1;
-  while ( (analogRead(JOY_X)<4094) && (pass==1))
+  while ( (analogRead(JOY_X)<4085) && (pass==1))
   {
     // Ensure no other buttons/joystick directions are pressed
     if ( (digitalRead(BUTTON_A) == 0) || 
@@ -197,7 +197,7 @@ int pressedRight(void)
          (digitalRead(JOY_SEL) == 0) )         
       pass = 0;
       
-    if ( (analogRead(JOY_Y)<10) || (analogRead(JOY_Y) >  4050) )
+    if ( (analogRead(JOY_Y)<10) || (analogRead(JOY_Y) >  4050) || (analogRead(JOY_X) < 10)  )
       pass = 0;    
     
   }  
@@ -216,7 +216,7 @@ int pressedDown(void)
          (digitalRead(JOY_SEL) == 0) )         
       pass = 0;
       
-    if ( (analogRead(JOY_X)<10) || (analogRead(JOY_X) >  4050) )
+    if ( (analogRead(JOY_X)<10) || (analogRead(JOY_X) >  4050) || (analogRead(JOY_Y) > 4085)  )
       pass = 0;    
     
   }  
@@ -225,7 +225,7 @@ int pressedDown(void)
 int pressedUp(void)
 {
   uint8_t pass  = 1;
-  while ( (analogRead(JOY_Y)<4094) && (pass==1))
+  while ( (analogRead(JOY_Y)<4085) && (pass==1))
   {
     // Ensure no other buttons/joystick directions are pressed
     if ( (digitalRead(BUTTON_A) == 0) || 
@@ -233,7 +233,7 @@ int pressedUp(void)
          (digitalRead(JOY_SEL) == 0) )         
       pass = 0;
       
-    if ( (analogRead(JOY_X)<10) || (analogRead(JOY_X) >  4050) )
+    if ( (analogRead(JOY_X)<10) || (analogRead(JOY_X) >  4050) || (analogRead(JOY_Y) < 10)  )
       pass = 0;    
     
   }  

--- a/build/shared/examples/09.EducationalBP_MKII/KonamiContraBuzzer/KonamiContraBuzzer.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/KonamiContraBuzzer/KonamiContraBuzzer.ino
@@ -92,6 +92,7 @@ int pressedStart(void);
 void setup()
 {
   // put your setup code here, to run once:
+  analogReadResolution(12); //added to ensure a 12 bit analog read resolution
   statemachine =0;
   pinMode(BUTTON_B, INPUT);
   pinMode(BUTTON_A, INPUT);
@@ -196,8 +197,7 @@ void loop()
       break; 
 
     //---BUTTON_B---             
-    case 8: // Waiting for Right       
-      delay(300);
+    case 8: // Waiting for buttonB       
       if (pressedB())       //Button B
           statemachine++;  
       else
@@ -205,7 +205,7 @@ void loop()
       break; 
 
     //---BUTTON_A---             
-    case 9: // Waiting for Right       
+    case 9: // Waiting for buttonA       
       if (pressedA())       //Button A
           statemachine++;  
       else
@@ -255,7 +255,7 @@ int pressedLeft(void)
          (digitalRead(JOY_SEL) == 0) )         
       pass = 0;
       
-    if ( (analogRead(JOY_Y)<10) || (analogRead(JOY_Y) >  4050) )
+    if ( (analogRead(JOY_Y)<10) || (analogRead(JOY_Y) >  4050) || (analogRead(JOY_X) > 4085)  )
       pass = 0;    
     
   }  
@@ -264,7 +264,7 @@ int pressedLeft(void)
 int pressedRight(void)
 {
   uint8_t pass  = 1;
-  while ( (analogRead(JOY_X)<4094) && (pass==1))
+  while ( (analogRead(JOY_X)<4085) && (pass==1))
   {
     // Ensure no other buttons/joystick directions are pressed
     if ( (digitalRead(BUTTON_A) == 0) || 
@@ -272,7 +272,7 @@ int pressedRight(void)
          (digitalRead(JOY_SEL) == 0) )         
       pass = 0;
       
-    if ( (analogRead(JOY_Y)<10) || (analogRead(JOY_Y) >  4050) )
+    if ( (analogRead(JOY_Y)<10) || (analogRead(JOY_Y) >  4050) || (analogRead(JOY_X) < 10)  )
       pass = 0;    
     
   }  
@@ -291,7 +291,7 @@ int pressedDown(void)
          (digitalRead(JOY_SEL) == 0) )         
       pass = 0;
       
-    if ( (analogRead(JOY_X)<10) || (analogRead(JOY_X) >  4050) )
+    if ( (analogRead(JOY_X)<10) || (analogRead(JOY_X) >  4050) || (analogRead(JOY_Y) > 4085)  )
       pass = 0;    
     
   }  
@@ -300,7 +300,7 @@ int pressedDown(void)
 int pressedUp(void)
 {
   uint8_t pass  = 1;
-  while ( (analogRead(JOY_Y)<4094) && (pass==1))
+  while ( (analogRead(JOY_Y)<4085) && (pass==1))
   {
     // Ensure no other buttons/joystick directions are pressed
     if ( (digitalRead(BUTTON_A) == 0) || 
@@ -308,7 +308,7 @@ int pressedUp(void)
          (digitalRead(JOY_SEL) == 0) )         
       pass = 0;
       
-    if ( (analogRead(JOY_X)<10) || (analogRead(JOY_X) >  4050) )
+    if ( (analogRead(JOY_X)<10) || (analogRead(JOY_X) >  4050) || (analogRead(JOY_Y) < 10)  )
       pass = 0;    
     
   }  

--- a/build/shared/examples/09.EducationalBP_MKII/LCD_Joystick/LCD_Joystick.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/LCD_Joystick/LCD_Joystick.ino
@@ -71,10 +71,7 @@ uint32_t z;
 // Add setup code
 void setup()
 {
-    // By default MSP432 has analogRead() set to 10 bits. 
-    // This Sketch assumes 12 bits. Uncomment to line below to set analogRead()
-    // to 12 bit resolution for MSP432.
-    //analogReadResolution(12);
+    analogReadResolution(12);  //added to ensure a 12 bit analog read resolution
 
     myScreen.begin();
     x00 = 0;

--- a/build/shared/examples/09.EducationalBP_MKII/LCD_LifeGame/LCD_LifeGame.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/LCD_LifeGame/LCD_LifeGame.ino
@@ -71,8 +71,10 @@ Screen_HX8353E myScreen;
 
 // Beware of RAM limitations
 #if defined(HX8353E)                                                            // Educational BoosterPack MKII
-
-#if defined(__MSP430F5529__) || defined(__CC2650__)
+#if defined(__MSP430FR6989__)
+#define ROWS 25
+#define COLS 25
+#elif defined(__MSP430F5529__) || defined(__CC2650__)
 #define ROWS 32 // max 80
 #define COLS 32 // max 60
 #elif defined(__LM4F120H5QR__) || defined(__TM4C123GH6PM__) || defined(__CC3200R1MXRGCR__)

--- a/build/shared/examples/09.EducationalBP_MKII/MicrophoneInLedOut/MicrophoneInLedOut.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/MicrophoneInLedOut/MicrophoneInLedOut.ino
@@ -35,10 +35,8 @@ int sensorValue = 0;        // value read from the pot
 int outputValue = 0;        // value output to the PWM (analog out)
 
 void setup() {
-  // By default MSP432 has analogRead() set to 10 bits. 
-  // This Sketch assumes 12 bits. Uncomment to line below to set analogRead()
-  // to 12 bit resolution for MSP432.
-  //analogReadResolution(12);
+
+  analogReadResolution(12); //added to ensure a 12 bit analog read resolution
 
   // initialize serial communications at 9600 bps:
   Serial.begin(9600); 

--- a/build/shared/examples/09.EducationalBP_MKII/ServoFromJoystick/ServoFromJoystick.ino
+++ b/build/shared/examples/09.EducationalBP_MKII/ServoFromJoystick/ServoFromJoystick.ino
@@ -23,18 +23,19 @@ This example code is in the public domain.
  
 Servo myservo;  // create servo object to control a servo 
  
-int potpin = 2;  // analog pin used to connect the potentiometer
+int joystickX = 2;  // analog pin used to measure the joystick value
 int val;    // variable to read the value from the analog pin 
  
 void setup() 
 { 
+  analogReadResolution(12); //added to ensure a 12 bit analog read resolution
   myservo.attach(19);  // attaches the servo on pin 9 to the servo object 
 } 
  
 void loop() 
 { 
-  val = analogRead(potpin);            // reads the value of the potentiometer (value between 0 and 1023) 
-  val = map(val, 0, 4096, 0, 179);     // scale it to use it with the servo (value between 0 and 180) 
+  val = analogRead(joystickX);            // reads the value of the joystick (value between 0 and 4096) 
+  val = map(val, 0, 4085, 0, 179);     // scale it to use it with the servo (value between 0 and 180) 
   myservo.write(val);                  // sets the servo position according to the scaled value 
   delay(15);                           // waits for the servo to get there 
 } 


### PR DESCRIPTION
These edits make the code compatible across multiple boards with a few
additional core file tweaks.  They have been tested on the MSP432,
MSP4305529, MSP430FR6989, and TivaC123.  

A change log can be seen below:

i.	AccelermoeterLED
1.	Permanently uncomment analogReadResolution(12)

ii.	AccelerometerSerial
1.	Permanently uncomment analogReadResolution(12)

iii.	EduBP_MKII_Production_Test
1.	Added analogReadResolution(12) 
2.	Changed joystick threshold for MSP432 to be able to trigger
3.	Change myScreen.setFontSize(1) instead of 2, line 372
4.	Add in opt3001

iv.	EduBP_MKII_Production_Test_Serial
1.	Added analogReadResolution(12)
2.	Changed joystick threshold
3.	Add in opt3001

v.	GatorHoleBuzzer
1.	Edited comments to fit the code
2.	Add delay for 432 and Tiva

vi.	joystickDrawColor
1.	add analogReadResolution(12)
2.	pinMode(drawButton, INPUT_PULLUP);
3.	pinMode(32,INPUT_PULLUP);
4.	pinMode(33,INPUT_PULLUP);

vii.	joystickSerial
1.	analogReadResolution(12)

viii.	KonamiContra
1.	Analogreadresolution(12)
2.	Fixed comments for buttonA and B, waiting for right
3.	Delete Delay for button B
4.	Lower threshold for push up and push right to 4085 for msp432
5.	Add condition to fail when waiting up and goes down, waiting left goes right etc

ix.	KonamiContraBuzzer
1.	Same as KonamiContra

x.	LCD_Joystick
1.	Permanently uncomment analogReadResolution(12)

xi.	LCD_LifeGame
1.	Add this into the board definitions above 
2.	#if defined(__MSP430FR6989__)
3.	#define ROWS 25
4.	#define COLS 25

xii.	MicophoneInLEDOut
1.	Permanently uncomment anologReadResolution(12)

xiii.	ServoFromJoystick
1.	Add analogreadResolution(12)
2.	Correct comments/variable names
