### PR TITLE
Updates to USB end function for MSP430

### DIFF
--- a/hardware/msp430/libraries/USBSerial/USBSerial.cpp
+++ b/hardware/msp430/libraries/USBSerial/USBSerial.cpp
@@ -122,9 +122,26 @@ void USBSerial::begin()
     __enable_interrupt();                           //Enable interrupts globally
 }
 
-void USBSerial::end()
+void USBSerial::end(uint8_t disableXTAL)
 {
   USB_disable();
+  if (disableXTAL){
+    if (USB_PLL_XT == 2){
+		XT2_Stop();
+    } else {
+		XT1_Stop();
+    }
+  }
+}
+
+void USBSerial::end()
+{
+	USB_disable();
+	if (USB_PLL_XT == 2){
+		XT2_Stop();
+	} else {
+		XT1_Stop();
+	}
 }
 
 

--- a/hardware/msp430/libraries/USBSerial/USBSerial.h
+++ b/hardware/msp430/libraries/USBSerial/USBSerial.h
@@ -43,6 +43,7 @@ public:
   ~USBSerial();
   void begin();
   void end();
+  void end(uint8_t disableXTAL);
   virtual int available(void);
   virtual int peek();
   virtual size_t write(uint8_t byte);


### PR DESCRIPTION
fixes issue reported in #884 
gives the option to disable the XTAL on USB::end