### PR TITLE
lm4f: EthernetClient clear cpcb on connect error

### DIFF
--- a/hardware/lm4f/libraries/Ethernet/EthernetClient.cpp
+++ b/hardware/lm4f/libraries/Ethernet/EthernetClient.cpp
@@ -192,6 +192,8 @@ int EthernetClient::connect(IPAddress ip, uint16_t port, unsigned long timeout) 
 
 	if (cs->cpcb->state != ESTABLISHED) {
 		_connected = false;
+		cs->cpcb = NULL;
+		return false;
 	}
 
 	/* Poll to determine if the peer is still alive */


### PR DESCRIPTION
patch fixes this situation:
 
EthernetClient a,b;

if(!a.connected()) a.connect("1.1.1.1",0); _//fail, pointer not cleared_
if(!b.connected()) b.connect("google.com",80); _//ok_
if(!a.connected()) a.connect("1.1.1.1",0); _//spoils b connection_
