### PR TITLE
Wrong RAM size in boards.txt msp430fr5739

### DIFF
--- a/hardware/msp430/boards.txt
+++ b/hardware/msp430/boards.txt
@@ -46,7 +46,7 @@ lpmsp430fr5739.build.mcu=msp430fr5739
 lpmsp430fr5739.build.f_cpu=16000000L
 lpmsp430fr5739.build.core=msp430
 lpmsp430fr5739.build.variant=fraunchpad
-lpmsp430fr5739.upload.maximum_ram_size=17408
+lpmsp430fr5739.upload.maximum_ram_size=1024
 
 ##############################################################
 


### PR DESCRIPTION
http://www.ti.com/product/MSP430FR5739
in ti site show msp430fr5739's RAM size is 1024. Is there any specific reason that set this RAM size 17408?

Thank you for creating a pull request and contributing to the Energia repository! 

Before opening the request, please review the following guidelines.

### Scope of the change

Describe the scope of the change.

Limit the number of modified lines of code and avoid unecessary modified lines (like `tab` replaced by `space`).

### Known limitations 

Describe any known limitations with the change.

Especially, list the impacted MCUs.

### Tests and examples

Run any tests or examples that can exercise the modified code. 
