### PR TITLE
issue with the begin function as master

### DIFF
--- a/hardware/lm4f/libraries/Wire/Wire.cpp
+++ b/hardware/lm4f/libraries/Wire/Wire.cpp
@@ -295,7 +295,8 @@ void TwoWire::begin(void)
   }
 
   ROM_SysCtlPeripheralEnable(g_uli2cPeriph[i2cModule]);
-
+  while (!ROM_SysCtlPeripheralReady(g_uli2cPeriph[i2cModule]))
+          {}
   //Configure GPIO pins for I2C operation
   ROM_GPIOPinConfigure(g_uli2cConfig[i2cModule][0]);
   ROM_GPIOPinConfigure(g_uli2cConfig[i2cModule][1]);


### PR DESCRIPTION
I had been trying to work with the i2c bus with a mpu6050, but it just did not work. So I added a while right after you enable the peripheral in the begin() function as master, it just worked out for me, i followed the tivaware reference guide example for i2c initialization

Thank you for creating a pull request and contributing to the Energia repository! 

Before opening the request, please review the following guidelines.

### Scope of the change

Describe the scope of the change.

Limit the number of modified lines of code and avoid unecessary modified lines (like `tab` replaced by `space`).

### Known limitations 

Describe any known limitations with the change.

Especially, list the impacted MCUs.

### Tests and examples

Run any tests or examples that can exercise the modified code. 
