### PR TITLE
Making the client objects protected so children classes can access th…

### DIFF
--- a/libraries/MQTTClient/EthernetStack.h
+++ b/libraries/MQTTClient/EthernetStack.h
@@ -67,7 +67,7 @@ public:
         return 0;
     }
 
-private:
+protected:
 
     EthernetClient client;
     

--- a/libraries/MQTTClient/WifiIPStack.h
+++ b/libraries/MQTTClient/WifiIPStack.h
@@ -68,7 +68,7 @@ public:
         return 0;
     }
     
-private:
+protected:
 
     WiFiClient iface;
     


### PR DESCRIPTION
…e underlying clients

fixes #1006


### Scope of the change
The scope is very limited to allowing access to the client objects of the EthernetStack and WifiIPStack classes to children classes, enabling a WifiIPStack that only talks TLS for example.


### Known limitations 

None

### Tests and examples

None 
