### PR TITLE
Boostxl sharp128

### DIFF
--- a/libraries/LCD_SharpBoosterPack_SPI/LCD_SharpBoosterPack_SPI.cpp
+++ b/libraries/LCD_SharpBoosterPack_SPI/LCD_SharpBoosterPack_SPI.cpp
@@ -3,7 +3,7 @@
 //  Example for library for Sharp BoosterPack LCD with hardware SPI
 //
 //
-//  Author :  StefanSch
+//  Author :  Stefan Schauer
 //  Date   :  Mar 05, 2015
 //  Version:  1.04
 //  File   :  LCD_SharpBoosterPack_SPI_main.c
@@ -11,11 +11,11 @@
 //  Version:  1.01 : added support for CC3200
 //  Version:  1.02 : added print class
 //  Version:  1.03 : added support for Sharp 128
-//  Version:  1.04 : added support for Data in FRAM
+//  version:  1.04 : horrible patch for CC13x0 ENERGIA_ARCH_CC13XX
 //
 //  Based on the LCD5110 Library
 //  Created by Rei VILO on 28/05/12
-//  Copyright (c) 2012 http://embeddedcomputing.weebly.com
+//  Copyright (c) 2012 https://embeddedcomputing.weebly.com
 //  Licence CC = BY SA NC
 //
 //  Edited 2015-07-11 by ReiVilo
@@ -73,7 +73,6 @@ unsigned char VCOMbit = 0x40;
 unsigned char flagSendToggleVCOMCommand = 0;
 #define SHARP_SEND_COMMAND_RUNNING          0x01
 #define SHARP_REQUEST_TOGGLE_VCOM           0x02
-
 
 
 static void SendToggleVCOMCommand(void);
@@ -540,9 +539,13 @@ static void SendToggleVCOMCommand(void)
         // Set P2.4 High for CS
         digitalWrite(_pinChipSelect, HIGH);
 
+#if defined(ENERGIA_ARCH_CC13XX)    // Horrible patch for CC13x0
+        shiftOut(15, 7, MSBFIRST, (char)command);
+        shiftOut(15, 7, MSBFIRST, (char)SHARP_LCD_TRAILER_BYTE);
+#else
         SPI.transfer((char)command);
         SPI.transfer((char)SHARP_LCD_TRAILER_BYTE);
-
+#endif
         // Wait for last byte to be sent, then drop SCS
         delayMicroseconds(10);
         // Set P2.4 High for CS

--- a/libraries/LCD_SharpBoosterPack_SPI/LCD_SharpBoosterPack_SPI.h
+++ b/libraries/LCD_SharpBoosterPack_SPI/LCD_SharpBoosterPack_SPI.h
@@ -3,9 +3,9 @@
 //  Example for library for Sharp BoosterPack LCD 96 and 128 with hardware SPI
 //
 //
-//  Author :  Stefan Schauer
+//  Author :  StefanSch
 //  Date   :  Mar 05, 2015
-//  Version:  1.02
+//  Version:  1.03
 //  File   :  LCD_SharpBoosterPack_SPI_main.h
 //
 //  Based on the LCD5110 Library
@@ -20,6 +20,9 @@
 //  Edited 15 Oct 2018 by ReiVilo
 //  Added support for Sharp 128 with minimal change
 //  Added flushReversed() for reversed display and preserved buffer
+//
+//  Edited 2019-03-19 by StefaSch
+//  Added support for smaller memory with put LCD data to FRAM
 //
 
 #ifndef LCD_SharpBoosterPack_SPI_h
@@ -72,7 +75,6 @@ class LCD_SharpBoosterPack_SPI : public Print
     /// @param	pinVCC VCC pin
     /// @param  model default=SHARP_96 for compatibility, SHARP_128
     ///
-    /// @note   For SensorTag CC2650
     /// @code
     ///     LCD_SharpBoosterPack_SPI myScreen(7, 10, 1, SHARP_96);
     ///     LCD_SharpBoosterPack_SPI myScreen(7, 10, 1, true, SHARP_128);
@@ -173,8 +175,6 @@ class LCD_SharpBoosterPack_SPI : public Print
     void TA0_turnOff();
     uint8_t _orientation;
     bool _reverse;
-    uint8_t lcd_vertical_max;
-    uint8_t lcd_horizontal_max;
 };
 #endif
 

--- a/libraries/LCD_SharpBoosterPack_SPI/LCD_SharpBoosterPack_SPI.h
+++ b/libraries/LCD_SharpBoosterPack_SPI/LCD_SharpBoosterPack_SPI.h
@@ -3,14 +3,14 @@
 //  Example for library for Sharp BoosterPack LCD 96 and 128 with hardware SPI
 //
 //
-//  Author :  StefanSch
+//  Author :  Stefan Schauer
 //  Date   :  Mar 05, 2015
-//  Version:  1.03
+//  Version:  1.04
 //  File   :  LCD_SharpBoosterPack_SPI_main.h
 //
 //  Based on the LCD5110 Library
 //  Created by Rei VILO on 28 May 2012
-//  Copyright (c) 2012 http://embeddedcomputing.weebly.com
+//  Copyright (c) 2012 https://embeddedcomputing.weebly.com
 //  Licence CC = BY SA NC
 //
 //  Edited 11 Jul 2015 by ReiVilo
@@ -23,6 +23,9 @@
 //
 //  Edited 2019-03-19 by StefaSch
 //  Added support for smaller memory with put LCD data to FRAM
+//
+//  Edited 22 Apr 2020 by ReiVilo
+//  Horrible patch for CC13x0 ENERGIA_ARCH_CC13XX
 //
 
 #ifndef LCD_SharpBoosterPack_SPI_h
@@ -75,6 +78,7 @@ class LCD_SharpBoosterPack_SPI : public Print
     /// @param	pinVCC VCC pin
     /// @param  model default=SHARP_96 for compatibility, SHARP_128
     ///
+    /// @note   For SensorTag CC2650
     /// @code
     ///     LCD_SharpBoosterPack_SPI myScreen(7, 10, 1, SHARP_96);
     ///     LCD_SharpBoosterPack_SPI myScreen(7, 10, 1, true, SHARP_128);
@@ -138,7 +142,7 @@ class LCD_SharpBoosterPack_SPI : public Print
 
     ///
     /// @brief    Get size àf the screen
-    /// @return   96 for 96x96 or &28 for 128x128
+    /// @return   96 for 96x96 or 128 for 128x128
     ///
     uint8_t getSize();
 
@@ -175,6 +179,8 @@ class LCD_SharpBoosterPack_SPI : public Print
     void TA0_turnOff();
     uint8_t _orientation;
     bool _reverse;
+    uint8_t lcd_vertical_max;
+    uint8_t lcd_horizontal_max;
 };
 #endif
 

--- a/libraries/OneMsTaskTimer/OneMsTaskTimer.cpp
+++ b/libraries/OneMsTaskTimer/OneMsTaskTimer.cpp
@@ -271,7 +271,7 @@ void OneMsTaskTimer_int(void)
 #define DEFAULT_TIMER 1
 uint32_t timer_index_ = DEFAULT_TIMER;
 static volatile uint32_t g_ulBase;
-Clock_Handle myClock = NULL;
+Clock_Handle myOneMsTaskTimerClock = NULL;
 void OneMsTaskTimer_int(UArg arg);
 
 void OneMsTaskTimer::start(uint32_t timer_index) {
@@ -279,19 +279,19 @@ void OneMsTaskTimer::start(uint32_t timer_index) {
     Error_Block eb;
     Error_init(&eb);
 
-    if (myClock == NULL){
+    if (myOneMsTaskTimerClock == NULL){
         Clock_Params_init(&clockParams);
         clockParams.period = (uint32_t)1000 / (uint64_t)Clock_tickPeriod;
         clockParams.startFlag = FALSE;
         clockParams.arg = (UArg)0x5555;
 
-		myClock = Clock_create(OneMsTaskTimer_int, clockParams.period, &clockParams, &eb);
+		myOneMsTaskTimerClock = Clock_create(OneMsTaskTimer_int, clockParams.period, &clockParams, &eb);
 	}
-    Clock_start(myClock);
+    Clock_start(myOneMsTaskTimerClock);
 }
 
 void OneMsTaskTimer::stop() {
-    Clock_stop(myClock);
+    Clock_stop(myOneMsTaskTimerClock);
 }
 void OneMsTaskTimer_int(UArg arg)
 {

--- a/libraries/OneMsTaskTimer/OneMsTaskTimer.h
+++ b/libraries/OneMsTaskTimer/OneMsTaskTimer.h
@@ -10,6 +10,8 @@
              added suppport for CC3200
 			 by Stefan Sch
  
+ 23 Apr 2020 - Renamed trivial myClock name to myOneMsTaskTimerClock to avoid prossible conflicts, by Rei Vilo
+ 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either


### PR DESCRIPTION
Workaround for #1059

As the CC1352 replaces the CC1350, this workaround is good)enough to patch #1059. 

+ **OneMsTaskTimer**
 23 Apr 2020 - Renamed trivial myClock name to myOneMsTaskTimerClock to avoid prossible conflicts, by Rei Vilo

+ **LCD_SharpBoosterPack_SPI**

Edited 22 Apr 2020 by ReiVilo
Horrible patch for CC13x0 ENERGIA_ARCH_CC13XX