### PR TITLE
Fix potential bug in Fade.ino example

### DIFF
--- a/build/shared/examples/01.Basics/Fade/Fade.ino
+++ b/build/shared/examples/01.Basics/Fade/Fade.ino
@@ -27,7 +27,7 @@ void loop()  {
   brightness = brightness + fadeAmount;
 
   // reverse the direction of the fading at the ends of the fade: 
-  if (brightness == 0 || brightness == 255) {
+  if (brightness <= 0 || brightness >= 255) {
     fadeAmount = -fadeAmount ; 
   }     
   // wait for 30 milliseconds to see the dimming effect    


### PR DESCRIPTION
With fade amounts that don't divide 255, the direction reversing won't work. This PR fixes that.

### Scope of the change

Just changes an early example.

Limit the number of modified lines of code and avoid unecessary modified lines (like `tab` replaced by `space`).

### Known limitations 

None.

### Tests and examples

N/A.
